### PR TITLE
RestTemplate → RestClient

### DIFF
--- a/src/main/java/com/zoopick/server/config/FastApiConfig.java
+++ b/src/main/java/com/zoopick/server/config/FastApiConfig.java
@@ -3,21 +3,26 @@ package com.zoopick.server.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestTemplate;
 import java.time.Duration;
+
 @Configuration
 public class FastApiConfig {
     private final FastApiProperties fastApiProperties;
+
     public FastApiConfig(FastApiProperties fastApiProperties) {
         this.fastApiProperties = fastApiProperties;
     }
 
     @Bean
-    public RestTemplate fastApiRestTemplate() {
+    public RestClient fastApiRestClient() {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(fastApiProperties.getVision().getConnectTimeout());
         factory.setReadTimeout(fastApiProperties.getVision().getReadTimeout());
 
-        return new RestTemplate(factory);
+        return RestClient.builder()
+                .requestFactory(factory)
+                .build();
     }
 }

--- a/src/main/java/com/zoopick/server/service/VisionService.java
+++ b/src/main/java/com/zoopick/server/service/VisionService.java
@@ -4,6 +4,7 @@ import com.zoopick.server.config.FastApiProperties;
 import com.zoopick.server.exception.BadRequestException;
 import com.zoopick.server.exception.DataNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestTemplate;
 
 import com.zoopick.server.dto.vision.VisionAnalyzeRequest;
@@ -14,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class VisionService {
-    private final RestTemplate fastApiRestTemplate;
+    private final RestClient fastApiRestClient;
     private final FastApiProperties fastApiProperties;
 
     public VisionAnalyzeResponse analyzeImage(String imageUrl) {
@@ -27,7 +28,11 @@ public class VisionService {
                 fastApiProperties.getVision().getAnalyzePath();
 
         try {
-            VisionAnalyzeResponse response = fastApiRestTemplate.postForObject(url, request, VisionAnalyzeResponse.class);
+            VisionAnalyzeResponse response = fastApiRestClient.post()
+                    .uri(url)
+                    .body(request)
+                    .retrieve()
+                    .body(VisionAnalyzeResponse.class);
             if (response == null) {
                 throw new DataNotFoundException("분석 결과", imageUrl);
             }


### PR DESCRIPTION
권장되는 최신 동기 클라이언트인 RestClient로 변경했습니다.
- 변경 이유: Spring에서 RestClient 사용이 권장된다는 것을 찾았습니다.
- 코드 가독성이 좋아집니다.
- 유지보수에 유리합니다.
- 기존과 동일한 방식으로 작동하여 기능의 차이는 없습니다.