### PR TITLE
마이페이지 프로필 조회 및 수정 API 구현

### DIFF
--- a/src/main/java/com/zoopick/server/controller/ProfileController.java
+++ b/src/main/java/com/zoopick/server/controller/ProfileController.java
@@ -1,0 +1,54 @@
+package com.zoopick.server.controller;
+
+import com.zoopick.server.dto.profile.ProfileSummaryResponse;
+import com.zoopick.server.dto.profile.ProfileUpdateRequest;
+import com.zoopick.server.service.ProfileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Profile API", description = "사용자 프로필 관련 API")
+@RestController
+@RequestMapping("/api/profiles")
+@RequiredArgsConstructor
+public class ProfileController {
+
+    private final ProfileService profileService;
+
+    @Operation(summary = "내 프로필 요약 조회", description = "현재 로그인한 사용자의 프로필 기본 정보와 활동 요약(게시글 수, 채팅방 수, 안 읽은 알림 수)을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "프로필 조회 성공")
+    })
+    @GetMapping("/me")
+    public ResponseEntity<ProfileSummaryResponse> getMyProfile(Authentication authentication) {
+        // JWT 토큰에서 추출된 email(또는 username)을 사용
+        String email = authentication.getName();
+        ProfileSummaryResponse response = profileService.getProfileSummary(email);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "내 프로필 정보 수정", description = "현재 로그인한 사용자의 닉네임과 학과 정보를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "프로필 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (이미 존재하는 닉네임인 경우)")
+    })
+    @PutMapping("/me")
+    public ResponseEntity<?> updateMyProfile(
+            Authentication authentication,
+            @RequestBody ProfileUpdateRequest request) {
+
+        try {
+            String email = authentication.getName();
+            profileService.updateProfile(email, request);
+            return ResponseEntity.ok().build();
+        } catch (IllegalStateException e) {
+            // 닉네임 중복 시 400 Bad Request 반환
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/zoopick/server/controller/ProfileController.java
+++ b/src/main/java/com/zoopick/server/controller/ProfileController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -26,7 +27,6 @@ public class ProfileController {
     })
     @GetMapping("/me")
     public ResponseEntity<ProfileSummaryResponse> getMyProfile(Authentication authentication) {
-        // JWT 토큰에서 추출된 email(또는 username)을 사용
         String email = authentication.getName();
         ProfileSummaryResponse response = profileService.getProfileSummary(email);
         return ResponseEntity.ok(response);
@@ -35,20 +35,15 @@ public class ProfileController {
     @Operation(summary = "내 프로필 정보 수정", description = "현재 로그인한 사용자의 닉네임과 학과 정보를 수정합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "프로필 수정 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 (이미 존재하는 닉네임인 경우)")
+            @ApiResponse(responseCode = "400", description = "잘못된 입력값 또는 이미 존재하는 닉네임인 경우"), // @Valid 예외 고려
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없는 경우")
     })
     @PutMapping("/me")
-    public ResponseEntity<?> updateMyProfile(
+    public ResponseEntity<Void> updateMyProfile(
             Authentication authentication,
-            @RequestBody ProfileUpdateRequest request) {
+            @RequestBody @Valid ProfileUpdateRequest request) { // @Valid 적용
 
-        try {
-            String email = authentication.getName();
-            profileService.updateProfile(email, request);
-            return ResponseEntity.ok().build();
-        } catch (IllegalStateException e) {
-            // 닉네임 중복 시 400 Bad Request 반환
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
+        profileService.updateProfile(authentication.getName(), request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/zoopick/server/dto/profile/ProfileSummaryResponse.java
+++ b/src/main/java/com/zoopick/server/dto/profile/ProfileSummaryResponse.java
@@ -1,0 +1,9 @@
+package com.zoopick.server.dto.profile;
+
+public record ProfileSummaryResponse(
+        String nickname,
+        String department,
+        long postCount,
+        long chatRoomCount,
+        long unreadNotificationCount) {
+}

--- a/src/main/java/com/zoopick/server/dto/profile/ProfileUpdateRequest.java
+++ b/src/main/java/com/zoopick/server/dto/profile/ProfileUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.zoopick.server.dto.profile;
+
+public record ProfileUpdateRequest(
+        String nickname,
+        String department
+) {
+}

--- a/src/main/java/com/zoopick/server/dto/profile/ProfileUpdateRequest.java
+++ b/src/main/java/com/zoopick/server/dto/profile/ProfileUpdateRequest.java
@@ -1,7 +1,13 @@
 package com.zoopick.server.dto.profile;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record ProfileUpdateRequest(
+
+        @NotBlank
         String nickname,
+
+        @NotBlank
         String department
 ) {
 }

--- a/src/main/java/com/zoopick/server/entity/User.java
+++ b/src/main/java/com/zoopick/server/entity/User.java
@@ -49,4 +49,10 @@ public class User {
     public List<GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority(role.name()));
     }
+
+
+    public void updateProfile(String nickname, String department) {
+        this.nickname = nickname;
+        this.department = department;
+    }
 }

--- a/src/main/java/com/zoopick/server/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zoopick/server/exception/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package com.zoopick.server.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 1. 닉네임 중복 등 비즈니스 로직 예외 (400 Bad Request)
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<String> handleIllegalStateException(IllegalStateException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+
+    // 2. 사용자를 찾을 수 없는 경우 (404 Not Found)
+    @ExceptionHandler(DataNotFoundException.class)
+    public ResponseEntity<String> handleDataNotFoundException(DataNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
+    // 3. @Valid 검증 실패 예외 (400 Bad Request)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleValidationException(MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMessage);
+    }
+}

--- a/src/main/java/com/zoopick/server/repository/ChatRoomRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ChatRoomRepository.java
@@ -26,4 +26,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     default Optional<ChatRoom> findByParticipantAndItemIdIs(User user, long itemId) {
         return findByOwnerOrFinderAndItemIdIs(user, user, itemId);
     }
+
+    long countByOwnerIdOrFinderId(Long ownerId, Long finderId);
 }

--- a/src/main/java/com/zoopick/server/repository/ItemPostRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ItemPostRepository.java
@@ -52,4 +52,6 @@ public interface ItemPostRepository extends JpaRepository<ItemPost, Long>, JpaSp
     default ItemPost findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(() -> DataNotFoundException.from("게시물", id));
     }
+
+    long countByUserId(Long userId);
 }

--- a/src/main/java/com/zoopick/server/repository/NotificationRepository.java
+++ b/src/main/java/com/zoopick/server/repository/NotificationRepository.java
@@ -11,4 +11,6 @@ public interface NotificationRepository extends JpaRepository<ZoopickNotificatio
     List<ZoopickNotification> findByUserIdOrderByCreatedAtDesc(Long userId);
 
     List<ZoopickNotification> findByUserIdAndReadAtIsNullOrderByCreatedAtDesc(Long userId);
+
+    long countByUserIdAndReadAtIsNull(Long userId);
 }

--- a/src/main/java/com/zoopick/server/repository/UserRepository.java
+++ b/src/main/java/com/zoopick/server/repository/UserRepository.java
@@ -24,4 +24,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
         return findByNickname(nickname)
                 .orElseThrow(() -> DataNotFoundException.from("사용자", nickname));
     }
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/zoopick/server/repository/UserRepository.java
+++ b/src/main/java/com/zoopick/server/repository/UserRepository.java
@@ -26,4 +26,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     }
 
     boolean existsByNickname(String nickname);
+
+
 }

--- a/src/main/java/com/zoopick/server/service/ProfileService.java
+++ b/src/main/java/com/zoopick/server/service/ProfileService.java
@@ -1,0 +1,59 @@
+package com.zoopick.server.service;
+
+import com.zoopick.server.dto.profile.ProfileSummaryResponse;
+import com.zoopick.server.dto.profile.ProfileUpdateRequest;
+import com.zoopick.server.entity.User;
+import com.zoopick.server.repository.ChatRoomRepository;
+import com.zoopick.server.repository.ItemPostRepository;
+import com.zoopick.server.repository.NotificationRepository;
+import com.zoopick.server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProfileService {
+
+    private final UserRepository userRepository;
+    private final ItemPostRepository itemPostRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final NotificationRepository notificationRepository;
+
+    // 내 프로필 요약 정보 조회
+    public ProfileSummaryResponse getProfileSummary(String email) {
+        User user = userRepository.findBySchoolEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        Long userId = user.getId();
+
+        long postCount = itemPostRepository.countByUserId(userId);
+        long chatRoomCount = chatRoomRepository.countByOwnerIdOrFinderId(userId, userId);
+        long unreadCount = notificationRepository.countByUserIdAndReadAtIsNull(userId);
+
+        return new ProfileSummaryResponse(
+                user.getNickname(),
+                user.getDepartment(),
+                postCount,
+                chatRoomCount,
+                unreadCount
+        );
+    }
+
+    // 프로필 정보 수정
+    @Transactional
+    public void updateProfile(String email, ProfileUpdateRequest request) {
+        User user = userRepository.findBySchoolEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        // 닉네임 중복 체크 (본인의 현재 닉네임과 다른데 이미 존재할 경우)
+        if (!user.getNickname().equals(request.nickname()) &&
+                userRepository.existsByNickname(request.nickname())) {
+            throw new IllegalStateException("이미 존재하는 닉네임입니다.");
+        }
+
+        // 엔티티 내 업데이트 메서드 호출
+        user.updateProfile(request.nickname(), request.department());
+    }
+}

--- a/src/main/java/com/zoopick/server/service/ProfileService.java
+++ b/src/main/java/com/zoopick/server/service/ProfileService.java
@@ -21,11 +21,9 @@ public class ProfileService {
     private final ChatRoomRepository chatRoomRepository;
     private final NotificationRepository notificationRepository;
 
-    // 내 프로필 요약 정보 조회
     public ProfileSummaryResponse getProfileSummary(String email) {
-        User user = userRepository.findBySchoolEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
-
+        // 공통 메서드 사용으로 DataNotFoundException 발생
+        User user = userRepository.findBySchoolEmailOrThrow(email);
         Long userId = user.getId();
 
         long postCount = itemPostRepository.countByUserId(userId);
@@ -41,19 +39,16 @@ public class ProfileService {
         );
     }
 
-    // 프로필 정보 수정
     @Transactional
     public void updateProfile(String email, ProfileUpdateRequest request) {
-        User user = userRepository.findBySchoolEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+        User user = userRepository.findBySchoolEmailOrThrow(email);
 
-        // 닉네임 중복 체크 (본인의 현재 닉네임과 다른데 이미 존재할 경우)
+        // 닉네임 중복 체크
         if (!user.getNickname().equals(request.nickname()) &&
                 userRepository.existsByNickname(request.nickname())) {
             throw new IllegalStateException("이미 존재하는 닉네임입니다.");
         }
 
-        // 엔티티 내 업데이트 메서드 호출
         user.updateProfile(request.nickname(), request.department());
     }
 }


### PR DESCRIPTION
-GET /api/profiles/me : 내 프로필 정보 및 작성글/채팅/알림 카운트 조회 로직 추가

-PUT /api/profiles/me : 닉네임 및 학과 수정 로직 추가

-닉네임 중복 변경 시도 시 400 Bad Request 예외 처리

-연관된 Repository, Service, DTO 클래스 생성

-각 Repository 카운트 쿼리 추가