### PR TITLE
이미지 업로드 용량 증가 및 item entity 수정 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ build/
 /target
 http/http-client.env.json
 http/test/
+
+/uploads/**
+!/uploads/**/
+!/uploads/**/.gitkeep

--- a/src/main/java/com/zoopick/server/dto/item/CreateItemPostRequest.java
+++ b/src/main/java/com/zoopick/server/dto/item/CreateItemPostRequest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.zoopick.server.entity.ItemCategory;
 import com.zoopick.server.entity.ItemColor;
 import com.zoopick.server.entity.ItemType;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -15,17 +15,29 @@ import java.time.LocalDateTime;
 @Setter
 @AllArgsConstructor
 public class CreateItemPostRequest {
-    @NotBlank
+    @NotNull
     private ItemType type;
+
+    @NotNull
+    private ItemCategory category;
+
+    @NotNull
+    private ItemColor color;
+
     private String title;
+
     private String description;
+
     @JsonProperty("image_url")
     private String imageUrl;
-    @NotBlank
+
+    @NotNull
     @JsonProperty("building_id")
     private long buildingId;
+
     @JsonProperty("detail_address")
     private String detailAddress;
+
     @JsonProperty("reported_at")
     private LocalDateTime reportedAt;
 }

--- a/src/main/java/com/zoopick/server/dto/item/ItemPostRecord.java
+++ b/src/main/java/com/zoopick/server/dto/item/ItemPostRecord.java
@@ -2,6 +2,7 @@ package com.zoopick.server.dto.item;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.zoopick.server.entity.ItemCategory;
+import com.zoopick.server.entity.ItemColor;
 import com.zoopick.server.entity.ItemStatus;
 import com.zoopick.server.entity.ItemType;
 import lombok.AllArgsConstructor;
@@ -22,6 +23,7 @@ public class ItemPostRecord {
     private ItemType type;
     private ItemStatus status;
     private ItemCategory category;
+    private ItemColor color;
     @JsonProperty("image_url")
     private String imageUrl;
     @JsonProperty("building_id")

--- a/src/main/java/com/zoopick/server/mapper/ItemPostMapper.java
+++ b/src/main/java/com/zoopick/server/mapper/ItemPostMapper.java
@@ -18,6 +18,7 @@ public class ItemPostMapper {
                 .type(itemPost.getItem().getType())
                 .status(itemPost.getItem().getStatus())
                 .category(itemPost.getItem().getCategory())
+                .color(itemPost.getItem().getColor())
                 .imageUrl(itemPost.getItem().getImageUrl())
                 .buildingId(itemPost.getItem().getReportedBuilding().getId())
                 .detailAddress(itemPost.getItem().getLocationName())

--- a/src/main/java/com/zoopick/server/service/ItemPostService.java
+++ b/src/main/java/com/zoopick/server/service/ItemPostService.java
@@ -38,13 +38,13 @@ public class ItemPostService {
                 .reporter(user)
                 .type(request.getType())
                 .status(ItemStatus.REPORTED)
-                .category(null)
-                .color(null)
+                .category(request.getCategory())
+                .color(request.getColor())
                 .embedding(null)
                 .reportedBuilding(building)
                 .locationName(request.getDetailAddress())
                 .imageUrl(request.getImageUrl())
-                .reportedAt(LocalDateTime.now())
+                .reportedAt(request.getReportedAt() != null ? request.getReportedAt() : LocalDateTime.now())
                 .build();
 
         Item savedItem = itemRepository.save(item);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,3 +41,6 @@ fastapi.cctv.read-timeout=3s
 zoopick.callback-url=${ZOOPICK_CALLBACK_URL:http://localhost:8080}
 zoopick.upload.image-dir=${ZOOPICK_UPLOAD_IMAGE_DIR:uploads/images}
 zoopick.cctv.snapshot-dir=${ZOOPICK_CCTV_SNAPSHOT_DIR:storage/cctv/snapshots}
+
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=20MB


### PR DESCRIPTION
Fix: image upload errors -> increase size of image files(default 1mb …-> 10mb, 20mb), add color column and category column in item entity

핸드폰 사진은 보통 4mb 이상이라 스프링 기본 어플리케이션 프로퍼티의 설정은 1mb이기 때문에 용량을 늘렸습니다

application properties 수정

```
spring.servlet.multipart.max-file-size=10MB
spring.servlet.multipart.max-request-size=20MB
``` 
추가 

그리고 item Entity 관련 category 및 color 컬럼이 없기에 추가해서 프론트와 통신이 가능하게 하였습니다 

./git ignore에는 이미지 파일 올라가지 않되 upload 폴더는 유지하게 할 수 있게 gitkeeper 추가 