### PR TITLE
Feat/item match

### DIFF
--- a/src/main/java/com/zoopick/server/controller/ItemMatchController.java
+++ b/src/main/java/com/zoopick/server/controller/ItemMatchController.java
@@ -1,0 +1,39 @@
+package com.zoopick.server.controller;
+
+import com.zoopick.server.dto.CommonResponse;
+import com.zoopick.server.dto.item.ItemMatchResultResponse;
+import com.zoopick.server.security.UserPrincipal;
+import com.zoopick.server.service.ItemMatchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Item Matching API", description = "아이템 매칭용 API")
+@RestController
+@RequestMapping("/api/matches")
+@RequiredArgsConstructor
+
+public class ItemMatchController {
+    private final ItemMatchService itemMatchService;
+
+    @Operation(summary = "매칭 조회", description = "유저의 잃어버린 아이템과 매칭된 아이템을 확인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "매칭 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "매칭을 찾을 수 없음")
+    })
+    @GetMapping("/me")
+    public CommonResponse<List<ItemMatchResultResponse>> itemMatchingResult(
+            @Parameter(description = "조회할 유저")
+            @AuthenticationPrincipal UserPrincipal principal) {
+        return CommonResponse.success(itemMatchService.getItemMatchResult(principal.id()));
+    }
+}

--- a/src/main/java/com/zoopick/server/dto/item/ItemCreatedEvent.java
+++ b/src/main/java/com/zoopick/server/dto/item/ItemCreatedEvent.java
@@ -1,0 +1,4 @@
+package com.zoopick.server.dto.item;
+
+public record ItemCreatedEvent(Long itemId) {
+}

--- a/src/main/java/com/zoopick/server/dto/item/ItemMatchProjection.java
+++ b/src/main/java/com/zoopick/server/dto/item/ItemMatchProjection.java
@@ -1,0 +1,14 @@
+package com.zoopick.server.dto.item;
+
+public interface ItemMatchProjection {
+    String getMatchId();
+    Long getFoundItemId();
+    Long getFoundPostId();
+    String getFoundPostTitle();
+    String getFoundImageUrl();
+    String getLocationName();
+    String getFoundNickname();
+    String getFoundDepartment();
+    Double getScore();
+    String getStatus();
+}

--- a/src/main/java/com/zoopick/server/dto/item/ItemMatchResultResponse.java
+++ b/src/main/java/com/zoopick/server/dto/item/ItemMatchResultResponse.java
@@ -1,0 +1,35 @@
+package com.zoopick.server.dto.item;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.zoopick.server.entity.MatchStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ItemMatchResultResponse {
+    @NotNull
+    @JsonProperty("match_id")
+    private String matchId;
+    @NotNull
+    @JsonProperty("found_item_id")
+    private long foundItemId;
+    @NotNull
+    @JsonProperty("found_post_id")
+    private long foundPostId;
+    @JsonProperty("found_post_title")
+    private String foundPostTitle;
+    @JsonProperty("found_image_url")
+    private String foundImageUrl;
+    @JsonProperty("locationName")
+    private String locationName;
+    @JsonProperty("found_nickname")
+    private String foundNickname;
+    @JsonProperty("found_department")
+    private String foundDepartment;
+    private double score;
+    private MatchStatus status;
+}

--- a/src/main/java/com/zoopick/server/dto/item/SimilarItemProjection.java
+++ b/src/main/java/com/zoopick/server/dto/item/SimilarItemProjection.java
@@ -1,0 +1,6 @@
+package com.zoopick.server.dto.item;
+
+public interface SimilarItemProjection {
+    Long getItemId();
+    Double getScore();
+}

--- a/src/main/java/com/zoopick/server/dto/item/SimilarItemResult.java
+++ b/src/main/java/com/zoopick/server/dto/item/SimilarItemResult.java
@@ -1,0 +1,14 @@
+package com.zoopick.server.dto.item;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class SimilarItemResult {
+
+    private Long itemId;
+    private double score;
+}

--- a/src/main/java/com/zoopick/server/entity/ItemMatch.java
+++ b/src/main/java/com/zoopick/server/entity/ItemMatch.java
@@ -45,4 +45,11 @@ public class ItemMatch {
     @Column(name = "updated_at")
     @Builder.Default
     private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @PrePersist
+    @PreUpdate
+    public void formatScore() {
+        // 저장 및 수정 직전에 0.85714...를 0.857로 변환
+        this.score = Math.round(this.score * 1000f) / 1000f;
+    }
 }

--- a/src/main/java/com/zoopick/server/entity/ItemMatch.java
+++ b/src/main/java/com/zoopick/server/entity/ItemMatch.java
@@ -1,0 +1,48 @@
+package com.zoopick.server.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "item_matches", schema = "zoopick")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ItemMatch {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "lost_item_id", nullable = false)
+    private Item lostItem;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "found_item_id", nullable = false)
+    private Item foundItem;
+
+    @NotNull
+    private float score;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    private MatchStatus status;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at")
+    @Builder.Default
+    private LocalDateTime updatedAt = LocalDateTime.now();
+}

--- a/src/main/java/com/zoopick/server/entity/MatchStatus.java
+++ b/src/main/java/com/zoopick/server/entity/MatchStatus.java
@@ -1,0 +1,8 @@
+package com.zoopick.server.entity;
+
+public enum MatchStatus {
+    CANDIDATE,
+    NOTIFIED,
+    CONFIRMED,
+    REJECTED
+}

--- a/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
@@ -16,13 +16,20 @@ import java.util.List;
 public interface ItemMatchRepository extends JpaRepository<ItemMatch, Long> {
 
     @Query(value = """
-    SELECT i.id as itemId, (1 - (i.embedding <=> CAST(:embedding AS vector))) as score
-    FROM zoopick.items i
-    WHERE i.type <> CAST(:excludeType AS item_type)
-      AND i.returned_at IS NULL
-      AND i.category = CAST(:category AS item_category)
-      AND i.color = CAST(:color AS item_color)
-      AND (1 - (i.embedding <=> CAST(:embedding AS vector))) >= :threshold
+    SELECT *
+    FROM (
+        SELECT
+            i.id,
+            1 - (i.embedding <=> CAST(:embedding AS vector)) AS score
+        FROM zoopick.items i
+        WHERE i.category = CAST(:category AS item_category)
+          AND i.color = CAST(:color AS item_color)
+          AND i.type <> CAST(:excludeType AS item_type)
+          AND i.returned_at IS NULL
+        ORDER BY i.embedding <=> CAST(:embedding AS vector)
+        LIMIT 100
+    ) t
+    WHERE t.score >= :threshold;
     """, nativeQuery = true)
     List<SimilarItemResult> findSimilarItems(@Param("embedding") Vector embedding,
                                              @Param("excludeType") String excludeType,

--- a/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
@@ -1,6 +1,7 @@
 package com.zoopick.server.repository;
 
-import com.zoopick.server.dto.item.SimilarItemResult;
+import com.zoopick.server.dto.item.ItemMatchProjection;
+import com.zoopick.server.dto.item.SimilarItemProjection;
 import com.zoopick.server.entity.Item;
 import com.zoopick.server.entity.ItemMatch;
 import org.springframework.data.domain.Vector;
@@ -29,14 +30,38 @@ public interface ItemMatchRepository extends JpaRepository<ItemMatch, Long> {
         ORDER BY i.embedding <=> CAST(:embedding AS vector)
         LIMIT 100
     ) t
-    WHERE t.score >= :threshold;
+    WHERE t.score >= :threshold
     """, nativeQuery = true)
-    List<SimilarItemResult> findSimilarItems(@Param("embedding") Vector embedding,
-                                             @Param("excludeType") String excludeType,
-                                             @Param("category") String category,
-                                             @Param("color") String color,
-                                             @Param("threshold") float threshold);
+    List<SimilarItemProjection> findSimilarItems(@Param("embedding") Vector embedding,
+                                                 @Param("excludeType") String excludeType,
+                                                 @Param("category") String category,
+                                                 @Param("color") String color,
+                                                 @Param("threshold") float threshold);
 
     // 중복 체크
     boolean existsByLostItemAndFoundItem(Item lostItem, Item foundItem);
+
+    @Query(value = """
+    SELECT 
+    m.id as matchId,                 -- 매칭 ID
+    f.id as foundItemId,             -- 매칭된 item ID
+    p.id as foundPostId,             -- 매칭된 post ID
+    p.title as foundPostTitle,       -- 매칭된 post 제목
+    f.location_name  as locationName,-- 매칭된 post 장소
+    f.image_url as foundImageUrl,    -- 매칭된 item 이미지 url
+    u.nickname as foundNickname,     -- 찾은 사람 닉네임
+    u.department as foundDepartment, -- 찾은 사람 과
+    m.score as score,                -- 매칭 점수
+    m.status as status               -- 현재 상태
+    FROM items i
+    JOIN item_matches m ON i.id = m.lost_item_id
+    JOIN items f ON m.found_item_id = f.id
+    JOIN item_posts p on f.id = p.item_id
+    JOIN users u ON u.id = f.reporter_id
+    WHERE i.type = 'LOST' -- 내가 잃어버린 것만
+    AND m.status IN ('CANDIDATE', 'NOTIFIED') -- 아직 매칭되지 않은 것들
+    AND i.reporter_id=:userId -- 내거만
+    ORDER BY m.score desc -- 내림차순으로 뽑음
+    """, nativeQuery = true)
+    List<ItemMatchProjection> itemMatchesByLostItem(@Param("userId") Long userId);
 }

--- a/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
@@ -1,0 +1,33 @@
+package com.zoopick.server.repository;
+
+import com.zoopick.server.dto.item.SimilarItemResult;
+import com.zoopick.server.entity.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+
+@Repository
+public interface ItemMatchRepository extends JpaRepository<ItemMatch, Long> {
+
+    @Query(value = """
+    SELECT i.id as itemId, (1 - (i.embedding <=> CAST(:embedding AS vector))) as score
+    FROM zoopick.items i
+    WHERE i.type <> CAST(:excludeType AS item_type)
+      AND i.returned_at IS NULL
+      AND i.category = CAST(:category AS item_category)
+      AND i.color = CAST(:color AS item_color)
+      AND (1 - (i.embedding <=> CAST(:embedding AS vector))) >= :threshold
+    """, nativeQuery = true)
+    List<SimilarItemResult> findSimilarItems(@Param("embedding") String embedding,
+                                             @Param("excludeType") String excludeType,
+                                             @Param("category") String category,
+                                             @Param("color") String color,
+                                             @Param("threshold") float threshold);
+
+    // 중복 체크
+    boolean existsByLostItemAndFoundItem(Item lostItem, Item foundItem);
+}

--- a/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
@@ -20,7 +20,7 @@ public interface ItemMatchRepository extends JpaRepository<ItemMatch, Long> {
     SELECT *
     FROM (
         SELECT
-            i.id,
+            i.id AS itemId,
             1 - (i.embedding <=> CAST(:embedding AS vector)) AS score
         FROM zoopick.items i
         WHERE i.category = CAST(:category AS item_category)
@@ -61,6 +61,7 @@ public interface ItemMatchRepository extends JpaRepository<ItemMatch, Long> {
     WHERE i.type = 'LOST' -- 내가 잃어버린 것만
     AND m.status IN ('CANDIDATE', 'NOTIFIED') -- 아직 매칭되지 않은 것들
     AND i.reporter_id=:userId -- 내거만
+    AND f.reporter_id<>:userId -- found한 아이템이 내거면 안됨
     ORDER BY m.score desc -- 내림차순으로 뽑음
     """, nativeQuery = true)
     List<ItemMatchProjection> itemMatchesByLostItem(@Param("userId") Long userId);

--- a/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
@@ -1,7 +1,9 @@
 package com.zoopick.server.repository;
 
 import com.zoopick.server.dto.item.SimilarItemResult;
-import com.zoopick.server.entity.*;
+import com.zoopick.server.entity.Item;
+import com.zoopick.server.entity.ItemMatch;
+import org.springframework.data.domain.Vector;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -22,7 +24,7 @@ public interface ItemMatchRepository extends JpaRepository<ItemMatch, Long> {
       AND i.color = CAST(:color AS item_color)
       AND (1 - (i.embedding <=> CAST(:embedding AS vector))) >= :threshold
     """, nativeQuery = true)
-    List<SimilarItemResult> findSimilarItems(@Param("embedding") String embedding,
+    List<SimilarItemResult> findSimilarItems(@Param("embedding") Vector embedding,
                                              @Param("excludeType") String excludeType,
                                              @Param("category") String category,
                                              @Param("color") String color,

--- a/src/main/java/com/zoopick/server/service/ItemMatchService.java
+++ b/src/main/java/com/zoopick/server/service/ItemMatchService.java
@@ -1,0 +1,53 @@
+package com.zoopick.server.service;
+
+import com.zoopick.server.dto.item.SimilarItemResult;
+import com.zoopick.server.entity.Item;
+import com.zoopick.server.entity.ItemMatch;
+import com.zoopick.server.entity.ItemType;
+import com.zoopick.server.entity.MatchStatus;
+import com.zoopick.server.repository.ItemMatchRepository;
+import com.zoopick.server.repository.ItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ItemMatchService {
+    private final ItemRepository itemRepository;
+    private final ItemMatchRepository itemMatchRepository;
+    @Value("${zoopick.similarity.threshold}")
+    private float similarityThreshold;
+    public void createMatch(Long itemId) {
+        Item targetItem = itemRepository.findByIdOrThrow(itemId); // 게시글이 올라간 아이템
+        String embedding = Arrays.toString(targetItem.getEmbedding()).replace(", ", ",");
+        List<SimilarItemResult> similarItems = itemMatchRepository.findSimilarItems(embedding,
+                                                                               targetItem.getType().name(),
+                                                                               targetItem.getCategory().name(),
+                                                                               targetItem.getColor().name(),
+                                                                               similarityThreshold);
+        if (!similarItems.isEmpty()) {
+            for (SimilarItemResult similarItemResult : similarItems) {
+                Item foundItemInDb = itemRepository.findByIdOrThrow(similarItemResult.getItemId());
+                // 게시글에 올라온 아이템이 LOST라면 lostItem에, FOUND라면 foundItem에
+                Item lostItem = targetItem.getType() == ItemType.LOST ? targetItem : foundItemInDb;
+                Item foundItem = targetItem.getType() == ItemType.LOST ? foundItemInDb : targetItem;
+                ItemMatch itemMatch = ItemMatch
+                        .builder()
+                        .score((float) similarItemResult.getScore())
+                        .lostItem(lostItem)
+                        .foundItem(foundItem)
+                        .status(MatchStatus.CANDIDATE)
+                        .build();
+                // 중복 저장 방지
+                if (!itemMatchRepository.existsByLostItemAndFoundItem(lostItem, foundItem))
+                    itemMatchRepository.save(itemMatch);
+            }
+        }
+    }
+}

--- a/src/main/java/com/zoopick/server/service/ItemMatchService.java
+++ b/src/main/java/com/zoopick/server/service/ItemMatchService.java
@@ -1,5 +1,6 @@
 package com.zoopick.server.service;
 
+import com.zoopick.server.dto.item.ItemMatchResultResponse;
 import com.zoopick.server.dto.item.SimilarItemResult;
 import com.zoopick.server.entity.Item;
 import com.zoopick.server.entity.ItemMatch;
@@ -29,11 +30,15 @@ public class ItemMatchService {
         log.info("매칭 시작 ID: {}", itemId);
         Item targetItem = itemRepository.findByIdOrThrow(itemId); // 게시글이 올라간 아이템
         Vector embedding = Vector.of(targetItem.getEmbedding());
-        List<SimilarItemResult> similarItems = itemMatchRepository.findSimilarItems(embedding,
-                                                                               targetItem.getType().name(),
-                                                                               targetItem.getCategory().name(),
-                                                                               targetItem.getColor().name(),
-                                                                               similarityThreshold);
+        List<SimilarItemResult> similarItems = itemMatchRepository.findSimilarItems(
+                        embedding,
+                        targetItem.getType().name(),
+                        targetItem.getCategory().name(),
+                        targetItem.getColor().name(),
+                        similarityThreshold)
+                .stream()
+                .map(p -> new SimilarItemResult(p.getItemId(), p.getScore()))
+                .toList();
         if (!similarItems.isEmpty()) {
             for (SimilarItemResult similarItemResult : similarItems) {
                 Item foundItemInDb = itemRepository.findByIdOrThrow(similarItemResult.getItemId());
@@ -53,7 +58,25 @@ public class ItemMatchService {
                     itemMatchRepository.save(itemMatch);
             }
         }
-        else log.warn("매칭된 아이템이 없습니다.", itemId);
+        else log.warn("매칭된 아이템이 없습니다.");
         log.info("매칭 종료 ID: {}", targetItem.getId());
+    }
+
+    public List<ItemMatchResultResponse> getItemMatchResult(Long userId) {
+        return itemMatchRepository.itemMatchesByLostItem(userId)
+                .stream()
+                .map(p -> new ItemMatchResultResponse(
+                        p.getMatchId(),
+                        p.getFoundItemId(),
+                        p.getFoundPostId(),
+                        p.getFoundPostTitle(),
+                        p.getFoundImageUrl(),
+                        p.getLocationName(),
+                        p.getFoundNickname(),
+                        p.getFoundDepartment(),
+                        p.getScore(),
+                        MatchStatus.valueOf(p.getStatus())
+                ))
+                .toList();
     }
 }

--- a/src/main/java/com/zoopick/server/service/ItemMatchService.java
+++ b/src/main/java/com/zoopick/server/service/ItemMatchService.java
@@ -8,24 +8,27 @@ import com.zoopick.server.entity.MatchStatus;
 import com.zoopick.server.repository.ItemMatchRepository;
 import com.zoopick.server.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Vector;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
 import java.util.List;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class ItemMatchService {
     private final ItemRepository itemRepository;
     private final ItemMatchRepository itemMatchRepository;
     @Value("${zoopick.similarity.threshold}")
     private float similarityThreshold;
     public void createMatch(Long itemId) {
+        log.info("매칭 시작 ID: {}", itemId);
         Item targetItem = itemRepository.findByIdOrThrow(itemId); // 게시글이 올라간 아이템
-        String embedding = Arrays.toString(targetItem.getEmbedding()).replace(", ", ",");
+        Vector embedding = Vector.of(targetItem.getEmbedding());
         List<SimilarItemResult> similarItems = itemMatchRepository.findSimilarItems(embedding,
                                                                                targetItem.getType().name(),
                                                                                targetItem.getCategory().name(),
@@ -34,6 +37,7 @@ public class ItemMatchService {
         if (!similarItems.isEmpty()) {
             for (SimilarItemResult similarItemResult : similarItems) {
                 Item foundItemInDb = itemRepository.findByIdOrThrow(similarItemResult.getItemId());
+                log.info("매칭된 아이템 ID: {}", foundItemInDb.getId());
                 // 게시글에 올라온 아이템이 LOST라면 lostItem에, FOUND라면 foundItem에
                 Item lostItem = targetItem.getType() == ItemType.LOST ? targetItem : foundItemInDb;
                 Item foundItem = targetItem.getType() == ItemType.LOST ? foundItemInDb : targetItem;
@@ -49,5 +53,7 @@ public class ItemMatchService {
                     itemMatchRepository.save(itemMatch);
             }
         }
+        else log.warn("매칭된 아이템이 없습니다.", itemId);
+        log.info("매칭 종료 ID: {}", targetItem.getId());
     }
 }

--- a/src/main/java/com/zoopick/server/service/ItemPostService.java
+++ b/src/main/java/com/zoopick/server/service/ItemPostService.java
@@ -48,7 +48,7 @@ public class ItemPostService {
                 .build();
 
         Item savedItem = itemRepository.save(item);
-        eventPublisher.publishEvent(savedItem.getId());
+        eventPublisher.publishEvent(new ItemCreatedEvent(savedItem.getId()));
 
         ItemPost itemPost = ItemPost.builder()
                 .title(request.getTitle())

--- a/src/main/java/com/zoopick/server/service/VisionService.java
+++ b/src/main/java/com/zoopick/server/service/VisionService.java
@@ -1,6 +1,7 @@
 package com.zoopick.server.service;
 
 import com.zoopick.server.config.FastApiProperties;
+import com.zoopick.server.dto.item.ItemCreatedEvent;
 import com.zoopick.server.dto.vision.VisionAnalyzeRequest;
 import com.zoopick.server.dto.vision.VisionAnalyzeResponse;
 import com.zoopick.server.entity.Item;
@@ -9,6 +10,7 @@ import com.zoopick.server.exception.DataNotFoundException;
 import com.zoopick.server.repository.ItemRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionPhase;
@@ -17,6 +19,7 @@ import org.springframework.web.client.RestClient;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class VisionService {
     private final RestClient fastApiRestClient;
     private final FastApiProperties fastApiProperties;
@@ -26,11 +29,12 @@ public class VisionService {
     //db에 commit한 이벤트를 받으면 실행
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleItemCreated(Long itemId) {
-        analyzeImage(itemId);
+    public void handleItemCreated(ItemCreatedEvent event) {
+        analyzeImage(event.itemId());
     }
 
     public void analyzeImage(Long itemId) {
+        log.info("전달된 아이템 ID: {}", itemId);
         Item item = itemRepository.findById(itemId).orElseThrow(() -> new EntityNotFoundException("아이템을 찾을 수 없습니다."));
         VisionAnalyzeRequest request = new VisionAnalyzeRequest(item.getImageUrl());
         String imageUrl = request.getImageUrl();

--- a/src/main/java/com/zoopick/server/service/VisionService.java
+++ b/src/main/java/com/zoopick/server/service/VisionService.java
@@ -21,6 +21,7 @@ public class VisionService {
     private final RestClient fastApiRestClient;
     private final FastApiProperties fastApiProperties;
     private final ItemRepository itemRepository;
+    private final ItemMatchService itemMatchService;
 
     //db에 commit한 이벤트를 받으면 실행
     @Async
@@ -51,6 +52,7 @@ public class VisionService {
             item.setColor(response.getColor());
             item.setEmbedding(response.getEmbedding());
             itemRepository.save(item);
+            itemMatchService.createMatch(item.getId());
         } catch (BadRequestException | DataNotFoundException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,3 +41,4 @@ fastapi.cctv.read-timeout=3s
 zoopick.callback-url=${ZOOPICK_CALLBACK_URL:http://localhost:8080}
 zoopick.upload.image-dir=${ZOOPICK_UPLOAD_IMAGE_DIR:uploads/images}
 zoopick.cctv.snapshot-dir=${ZOOPICK_CCTV_SNAPSHOT_DIR:storage/cctv/snapshots}
+zoopick.similarity.threshold=${ZOOPICK_SIMILARITY_THRESHOLD:0.85}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,6 +38,8 @@ fastapi.cctv.enqueue-path=/cctv/enqueue
 fastapi.cctv.status-path=/cctv/status
 fastapi.cctv.connect-timeout=3s
 fastapi.cctv.read-timeout=3s
+
 zoopick.callback-url=${ZOOPICK_CALLBACK_URL:http://localhost:8080}
 zoopick.upload.image-dir=${ZOOPICK_UPLOAD_IMAGE_DIR:uploads/images}
 zoopick.cctv.snapshot-dir=${ZOOPICK_CCTV_SNAPSHOT_DIR:storage/cctv/snapshots}
+zoopick.similarity.threshold=${ZOOPICK_SIMILARITY_THRESHOLD:0.85}

--- a/zoopick_dump.sql
+++ b/zoopick_dump.sql
@@ -1505,12 +1505,19 @@ ALTER TABLE ONLY zoopick.users
 ALTER TABLE ONLY zoopick.users
     ADD CONSTRAINT users_school_email_key UNIQUE (school_email);
 
+--
+-- Name: idx_items_embedding_hnsw; Type: INDEX; Schema: zoopick; Owner: postgres
+--
+
+CREATE INDEX idx_items_embedding_hnsw ON zoopick.items USING hnsw (embedding vector_cosine_ops);
+
+
 
 --
--- Name: idx_items_cat_color_id; Type: INDEX; Schema: zoopick; Owner: postgres
+-- Name: idx_items_filtering; Type: INDEX; Schema: zoopick; Owner: postgres
 --
 
-CREATE INDEX idx_items_cat_color_id ON zoopick.items (category, color, id);
+CREATE INDEX idx_items_filtering ON zoopick.items (category, color);
 
 
 --

--- a/zoopick_dump.sql
+++ b/zoopick_dump.sql
@@ -581,11 +581,7 @@ CREATE TABLE zoopick.item_matches (
                                       id bigint NOT NULL,
                                       lost_item_id bigint NOT NULL,
                                       found_item_id bigint NOT NULL,
-                                      score_category real,
-                                      score_visual real,
-                                      score_spatial real,
-                                      score_temporal real,
-                                      score_total real NOT NULL,
+                                      score real NOT NULL,
                                       status zoopick.match_status DEFAULT 'CANDIDATE'::zoopick.match_status NOT NULL,
                                       created_at timestamp without time zone DEFAULT now() NOT NULL,
                                       updated_at timestamp without time zone
@@ -1095,7 +1091,7 @@ COPY zoopick.courses (id, course_name, room_id, year, semester, day_of_week, sta
 -- Data for Name: item_matches; Type: TABLE DATA; Schema: zoopick; Owner: postgres
 --
 
-COPY zoopick.item_matches (id, lost_item_id, found_item_id, score_category, score_visual, score_spatial, score_temporal, score_total, status, created_at, updated_at) FROM stdin;
+COPY zoopick.item_matches (id, lost_item_id, found_item_id, score, status, created_at, updated_at) FROM stdin;
 \.
 
 
@@ -1508,6 +1504,13 @@ ALTER TABLE ONLY zoopick.users
 
 ALTER TABLE ONLY zoopick.users
     ADD CONSTRAINT users_school_email_key UNIQUE (school_email);
+
+
+--
+-- Name: idx_items_cat_color_id; Type: INDEX; Schema: zoopick; Owner: postgres
+--
+
+CREATE INDEX idx_items_cat_color_id ON zoopick.items (category, color, id);
 
 
 --


### PR DESCRIPTION
# PR: feat/item-match → master
 
## 개요
분실물 아이템 매칭 기능을 구현합니다.
이미지 분석 완료 후 pgvector 기반 유사도 검색으로 자동 매칭하고, 사용자가 본인의 매칭 결과를 조회할 수 있는 API를 제공합니다.
 
---
 
## 커밋 목록
 
| 커밋 | 내용 |
|------|------|
| `cc35cf9` | 아이템 매칭 관련 엔티티 추가 및 dump 수정 |
| `29594e6` | 아이템 매칭 서비스 구현 |
| `ce7e087` | 아이템 매칭 로깅 추가 및 Vector 타입 적용 |
| `904d419` | 유사도 점수 소수점 셋째 자리 포맷팅 적용 |
| `34791e4` | HNSW 기반 embedding 검색 인덱스 추가 및 쿼리 수정 |
| `a90343b` | 매칭 결과 DTO 및 Projection 추가 |
| `7238098` | 분실물 매칭 조회 API 및 서비스 로직 구현 |
 
---
 
## 변경 파일 목록
 
### 신규 추가
- `ItemMatchController.java`
- `ItemMatchService.java`
- `ItemMatchRepository.java`
- `ItemMatch.java`
- `MatchStatus.java`
- `ItemMatchResultResponse.java`
- `ItemMatchProjection.java`
- `SimilarItemResult.java`
- `SimilarItemProjection.java`
### 수정
- `VisionService.java` - 이미지 분석 완료 후 매칭 트리거 추가
- `application.properties` - `zoopick.similarity.threshold` 프로퍼티 추가
- `zoopick_dump.sql` - 스키마 및 인덱스 변경
---
 
## 주요 변경사항
 
### 1. 아이템 매칭 엔티티 (`ItemMatch`, `MatchStatus`)
- `score_category`, `score_visual` 등 개별 점수 컬럼을 단일 `score` 컬럼으로 통합
- `MatchStatus` enum: `CANDIDATE`, `NOTIFIED`, `CONFIRMED`, `REJECTED`
- `@PrePersist` / `@PreUpdate`로 score 소수점 셋째 자리 자동 포맷팅
### 2. 매칭 서비스 (`ItemMatchService`)
 
**`createMatch(Long itemId)`**
- 게시글 등록 아이템의 embedding을 기반으로 pgvector 유사도 검색 실행
- `SimilarItemProjection` → `SimilarItemResult` DTO 변환 후 처리
- `LOST` / `FOUND` 타입에 따라 lostItem, foundItem 자동 분류
- `existsByLostItemAndFoundItem`으로 중복 저장 방지
**`getItemMatchResult(Long userId)`**
- 내 분실 아이템 기준 매칭 결과 조회
- `ItemMatchProjection` → `ItemMatchResultResponse` DTO 변환하여 반환
- `@Transactional(readOnly = true)` 적용 권장

Item Post: id 93 'FOUND'
<img width="397" height="654" alt="스크린샷 2026-05-08 20 38 36" src="https://github.com/user-attachments/assets/57f3ba87-2a90-4289-bdca-93f20c238e79" />

매칭 logging
<img width="850" height="392" alt="스크린샷 2026-05-08 20 38 41" src="https://github.com/user-attachments/assets/b4ef0d35-1f05-4ecc-88d8-497c90d608ac" />

매칭 결과
<img width="778" height="194" alt="스크린샷 2026-05-08 20 38 45" src="https://github.com/user-attachments/assets/e72f69ac-bb9a-4394-8fad-af23c23a7eb2" />


### 3. 매칭 조회 API (`ItemMatchController`)
```
GET /api/matches/me
Authorization: Bearer {token}
```
> 매칭된 데이터는 배열 형태로 제공됩니다.

**Response**
<img width="385" height="485" alt="스크린샷 2026-05-08 19 37 51" src="https://github.com/user-attachments/assets/ac744b63-3c17-4c5d-9393-630e0cfc1d0c" />
 
### 4. Native Query 및 Projection 구조
Native Query 결과를 클래스 DTO로 직접 매핑할 수 없기 때문에 Projection 인터페이스를 중간 계층으로 사용합니다.
 
```
Native Query → Projection 인터페이스 → DTO 변환 (Service)
```
 
| Projection | DTO |
|---|---|
| `SimilarItemProjection` | `SimilarItemResult` |
| `ItemMatchProjection` | `ItemMatchResultResponse` |
 
### 5. DB 인덱스 추가 (`zoopick_dump.sql`)
```sql
-- pgvector HNSW 인덱스 (코사인 유사도 검색 최적화)
CREATE INDEX idx_items_embedding_hnsw ON zoopick.items USING hnsw (embedding vector_cosine_ops);
 
-- 필터링 인덱스 (category, color 조건 최적화)
CREATE INDEX idx_items_filtering ON zoopick.items (category, color);
```
 
### 6. VisionService 연동
이미지 분석 완료 후 자동으로 매칭을 트리거합니다.
```java
itemMatchService.createMatch(item.getId());
```
 
---

### PR 이후 다음 우선순위 작업
- [ ]  `POST /api/matches/{matchId}/confirm` — 매칭 수락 (CONFIRMED)
    - 다른 같은 found_item의 매칭은 자동 REJECTED 처리
- [ ]  `POST /api/matches/{matchId}/reject` — 매칭 거절 (REJECTED)
- [ ]  `POST /api/matches/manual` — 수동 매칭 (시나리오 ④ 게시판)
    - Body: `{ lostItemId, foundItemId }`
    - score_total = 1.0, status = CONFIRMED 자동