### PR TITLE
Feat: timetable crud api

### DIFF
--- a/http/timetable.http
+++ b/http/timetable.http
@@ -2,6 +2,17 @@
 GET {{baseUrl}}/api/timetables?year=2024&semester=1
 Authorization: Bearer {{accessToken}}
 
+### 새 시간표 만들기
+POST {{baseUrl}}/api/timetables
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "name": "플랜 B",
+  "year": 2024,
+  "semester": 1
+}
+
 ### 특정 시간표 상세 조회
 # @id: timetableId는 목록 조회에서 얻은 ID를 사용하세요.
 GET {{baseUrl}}/api/timetables/1

--- a/http/timetable.http
+++ b/http/timetable.http
@@ -1,0 +1,30 @@
+### 내 시간표 목록 조회
+GET {{baseUrl}}/api/timetables?year=2024&semester=1
+Authorization: Bearer {{accessToken}}
+
+### 특정 시간표 상세 조회
+# @id: timetableId는 목록 조회에서 얻은 ID를 사용하세요.
+GET {{baseUrl}}/api/timetables/1
+Authorization: Bearer {{accessToken}}
+
+### 시간표 동기화 (Sync)
+POST {{baseUrl}}/api/timetables/1/sync
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "courses": [
+    {
+      "courseId": 1,
+      "color": "#FF5733"
+    },
+    {
+      "courseId": 2,
+      "color": "#33FF57"
+    }
+  ]
+}
+
+### 강의 검색
+GET {{baseUrl}}/api/courses?year=2024&semester=1&keyword=데이터&page=0&size=10
+Authorization: Bearer {{accessToken}}

--- a/src/main/java/com/zoopick/server/controller/TimetableController.java
+++ b/src/main/java/com/zoopick/server/controller/TimetableController.java
@@ -1,14 +1,15 @@
 package com.zoopick.server.controller;
 
 import com.zoopick.server.dto.CommonResponse;
+import com.zoopick.server.dto.timetable.CreateTimetableRequest;
 import com.zoopick.server.dto.timetable.TimetableCourseResponse;
 import com.zoopick.server.dto.timetable.TimetableGroupResponse;
 import com.zoopick.server.dto.timetable.TimetableSyncRequest;
-import com.zoopick.server.entity.User;
 import com.zoopick.server.security.UserPrincipal;
 import com.zoopick.server.service.TimetableService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -31,6 +32,14 @@ public class TimetableController {
             @RequestParam Integer year,
             @RequestParam Integer semester) {
         return CommonResponse.success(timetableService.getTimetableGroups(principal.email(), year, semester));
+    }
+
+    @Operation(summary = "새 시간표 만들기", description = "특정 연도/학기에 새로운 시간표 그룹을 생성합니다.")
+    @PostMapping("/timetables")
+    public CommonResponse<TimetableGroupResponse> createTimetable(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody CreateTimetableRequest request) {
+        return CommonResponse.success(timetableService.createTimetable(principal.email(), request));
     }
 
     @Operation(summary = "시간표 상세 조회", description = "특정 시간표의 상세 강의 목록을 가져옵니다.")

--- a/src/main/java/com/zoopick/server/controller/TimetableController.java
+++ b/src/main/java/com/zoopick/server/controller/TimetableController.java
@@ -1,0 +1,63 @@
+package com.zoopick.server.controller;
+
+import com.zoopick.server.dto.CommonResponse;
+import com.zoopick.server.dto.timetable.TimetableCourseResponse;
+import com.zoopick.server.dto.timetable.TimetableGroupResponse;
+import com.zoopick.server.dto.timetable.TimetableSyncRequest;
+import com.zoopick.server.entity.User;
+import com.zoopick.server.security.UserPrincipal;
+import com.zoopick.server.service.TimetableService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Timetable API", description = "시간표 관리 및 강의 조회 API")
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class TimetableController {
+    private final TimetableService timetableService;
+
+    @Operation(summary = "내 시간표 목록 조회", description = "특정 연도/학기의 시간표 그룹 목록을 가져옵니다.")
+    @GetMapping("/timetables")
+    public CommonResponse<List<TimetableGroupResponse>> getTimetableGroups(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam Integer year,
+            @RequestParam Integer semester) {
+        return CommonResponse.success(timetableService.getTimetableGroups(principal.email(), year, semester));
+    }
+
+    @Operation(summary = "시간표 상세 조회", description = "특정 시간표의 상세 강의 목록을 가져옵니다.")
+    @GetMapping("/timetables/{id}")
+    public CommonResponse<List<TimetableCourseResponse>> getTimetableDetails(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long id) {
+        return CommonResponse.success(timetableService.getTimetableDetails(principal.email(), id));
+    }
+
+    @Operation(summary = "시간표 동기화", description = "현재 시간표의 강의 목록과 색상을 일괄 저장합니다.")
+    @PostMapping("/timetables/{id}/sync")
+    public CommonResponse<String> syncTimetable(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long id,
+            @RequestBody TimetableSyncRequest request) {
+        timetableService.syncTimetable(principal.email(), id, request);
+        return CommonResponse.success("Successfully synced");
+    }
+
+    @Operation(summary = "강의 검색", description = "시스템에 등록된 전체 강의 마스터 데이터를 검색합니다.")
+    @GetMapping("/courses")
+    public CommonResponse<Page<TimetableCourseResponse>> searchCourses(
+            @RequestParam Integer year,
+            @RequestParam Integer semester,
+            @RequestParam(required = false) String keyword,
+            Pageable pageable) {
+        return CommonResponse.success(timetableService.searchCourses(year, semester, keyword, pageable));
+    }
+}

--- a/src/main/java/com/zoopick/server/dto/timetable/CreateTimetableRequest.java
+++ b/src/main/java/com/zoopick/server/dto/timetable/CreateTimetableRequest.java
@@ -1,0 +1,15 @@
+package com.zoopick.server.dto.timetable;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateTimetableRequest(
+    @NotBlank(message = "시간표 이름을 입력해주세요.")
+    String name,
+    
+    @NotNull(message = "연도를 입력해주세요.")
+    Integer year,
+    
+    @NotNull(message = "학기를 입력해주세요.")
+    Integer semester
+) {}

--- a/src/main/java/com/zoopick/server/dto/timetable/TimetableCourseResponse.java
+++ b/src/main/java/com/zoopick/server/dto/timetable/TimetableCourseResponse.java
@@ -1,0 +1,16 @@
+package com.zoopick.server.dto.timetable;
+
+import com.zoopick.server.entity.Course;
+import java.time.LocalTime;
+
+public record TimetableCourseResponse(
+    Long courseId,
+    String courseName,
+    Course.DayOfWeek dayOfWeek,
+    LocalTime startTime,
+    LocalTime endTime,
+    String roomName,
+    String buildingName,
+    String buildingCode,
+    String color
+) {}

--- a/src/main/java/com/zoopick/server/dto/timetable/TimetableGroupResponse.java
+++ b/src/main/java/com/zoopick/server/dto/timetable/TimetableGroupResponse.java
@@ -1,0 +1,7 @@
+package com.zoopick.server.dto.timetable;
+
+public record TimetableGroupResponse(
+    Long timetableId,
+    String name,
+    Boolean isPrimary
+) {}

--- a/src/main/java/com/zoopick/server/dto/timetable/TimetableSyncRequest.java
+++ b/src/main/java/com/zoopick/server/dto/timetable/TimetableSyncRequest.java
@@ -1,0 +1,12 @@
+package com.zoopick.server.dto.timetable;
+
+import java.util.List;
+
+public record TimetableSyncRequest(
+    List<CourseColorRequest> courses
+) {
+    public record CourseColorRequest(
+        Long courseId,
+        String color
+    ) {}
+}

--- a/src/main/java/com/zoopick/server/entity/Course.java
+++ b/src/main/java/com/zoopick/server/entity/Course.java
@@ -1,0 +1,49 @@
+package com.zoopick.server.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "courses", schema = "zoopick")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Course {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "course_name", length = 100, nullable = false)
+    private String courseName;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "room_id", nullable = false)
+    private Room room;
+
+    @Column(nullable = false)
+    private Integer year;
+
+    @Column(nullable = false)
+    private Integer semester;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "day_of_week", nullable = false)
+    private DayOfWeek dayOfWeek;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    public enum DayOfWeek {
+        MON, TUE, WED, THU, FRI, SAT, SUN
+    }
+}

--- a/src/main/java/com/zoopick/server/entity/Timetable.java
+++ b/src/main/java/com/zoopick/server/entity/Timetable.java
@@ -1,0 +1,35 @@
+package com.zoopick.server.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "timetables", schema = "zoopick")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Timetable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "timetable_group_id", nullable = false)
+    private TimetableGroup timetableGroup;
+
+    @Column(length = 7)
+    @Builder.Default
+    private String color = "#3366FF";
+
+    @Column(name = "enrolled_at", nullable = false, updatable = false)
+    @Builder.Default
+    private LocalDateTime enrolledAt = LocalDateTime.now();
+}

--- a/src/main/java/com/zoopick/server/entity/TimetableGroup.java
+++ b/src/main/java/com/zoopick/server/entity/TimetableGroup.java
@@ -1,0 +1,40 @@
+package com.zoopick.server.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "timetable_groups", schema = "zoopick")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class TimetableGroup {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(length = 100, nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer year;
+
+    @Column(nullable = false)
+    private Integer semester;
+
+    @Column(name = "is_primary", nullable = false)
+    @Builder.Default
+    private Boolean isPrimary = false;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/src/main/java/com/zoopick/server/repository/CourseRepository.java
+++ b/src/main/java/com/zoopick/server/repository/CourseRepository.java
@@ -1,0 +1,17 @@
+package com.zoopick.server.repository;
+
+import com.zoopick.server.entity.Course;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CourseRepository extends JpaRepository<Course, Long> {
+    @Query("SELECT c FROM Course c WHERE c.year = :year AND c.semester = :semester " +
+           "AND (:keyword IS NULL OR c.courseName LIKE %:keyword%)")
+    Page<Course> searchCourses(@Param("year") Integer year, 
+                               @Param("semester") Integer semester, 
+                               @Param("keyword") String keyword, 
+                               Pageable pageable);
+}

--- a/src/main/java/com/zoopick/server/repository/TimetableGroupRepository.java
+++ b/src/main/java/com/zoopick/server/repository/TimetableGroupRepository.java
@@ -1,0 +1,13 @@
+package com.zoopick.server.repository;
+
+import com.zoopick.server.entity.TimetableGroup;
+import com.zoopick.server.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TimetableGroupRepository extends JpaRepository<TimetableGroup, Long> {
+    List<TimetableGroup> findAllByUserAndYearAndSemester(User user, Integer year, Integer semester);
+    Optional<TimetableGroup> findByIdAndUser(Long id, User user);
+}

--- a/src/main/java/com/zoopick/server/repository/TimetableRepository.java
+++ b/src/main/java/com/zoopick/server/repository/TimetableRepository.java
@@ -1,0 +1,12 @@
+package com.zoopick.server.repository;
+
+import com.zoopick.server.entity.Timetable;
+import com.zoopick.server.entity.TimetableGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TimetableRepository extends JpaRepository<Timetable, Long> {
+    List<Timetable> findAllByTimetableGroup(TimetableGroup timetableGroup);
+    void deleteAllByTimetableGroup(TimetableGroup timetableGroup);
+}

--- a/src/main/java/com/zoopick/server/service/TimetableService.java
+++ b/src/main/java/com/zoopick/server/service/TimetableService.java
@@ -1,5 +1,6 @@
 package com.zoopick.server.service;
 
+import com.zoopick.server.dto.timetable.CreateTimetableRequest;
 import com.zoopick.server.dto.timetable.TimetableCourseResponse;
 import com.zoopick.server.dto.timetable.TimetableGroupResponse;
 import com.zoopick.server.dto.timetable.TimetableSyncRequest;
@@ -33,6 +34,25 @@ public class TimetableService {
         return groupRepository.findAllByUserAndYearAndSemester(user, year, semester).stream()
                 .map(g -> new TimetableGroupResponse(g.getId(), g.getName(), g.getIsPrimary()))
                 .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public TimetableGroupResponse createTimetable(String email, CreateTimetableRequest request) {
+        User user = userRepository.findBySchoolEmailOrThrow(email);
+        
+        // 해당 학기의 첫 시간표라면 기본(primary)으로 설정
+        boolean isFirst = groupRepository.findAllByUserAndYearAndSemester(user, request.year(), request.semester()).isEmpty();
+
+        TimetableGroup group = TimetableGroup.builder()
+                .user(user)
+                .name(request.name())
+                .year(request.year())
+                .semester(request.semester())
+                .isPrimary(isFirst)
+                .build();
+                
+        TimetableGroup saved = groupRepository.save(group);
+        return new TimetableGroupResponse(saved.getId(), saved.getName(), saved.getIsPrimary());
     }
 
     public List<TimetableCourseResponse> getTimetableDetails(String email, Long timetableId) {

--- a/src/main/java/com/zoopick/server/service/TimetableService.java
+++ b/src/main/java/com/zoopick/server/service/TimetableService.java
@@ -1,0 +1,111 @@
+package com.zoopick.server.service;
+
+import com.zoopick.server.dto.timetable.TimetableCourseResponse;
+import com.zoopick.server.dto.timetable.TimetableGroupResponse;
+import com.zoopick.server.dto.timetable.TimetableSyncRequest;
+import com.zoopick.server.entity.*;
+import com.zoopick.server.exception.BadRequestException;
+import com.zoopick.server.exception.DataNotFoundException;
+import com.zoopick.server.repository.CourseRepository;
+import com.zoopick.server.repository.TimetableGroupRepository;
+import com.zoopick.server.repository.TimetableRepository;
+import com.zoopick.server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TimetableService {
+    private final TimetableGroupRepository groupRepository;
+    private final TimetableRepository timetableRepository;
+    private final CourseRepository courseRepository;
+    private final UserRepository userRepository;
+
+    public List<TimetableGroupResponse> getTimetableGroups(String email, Integer year, Integer semester) {
+        User user = userRepository.findBySchoolEmailOrThrow(email);
+        return groupRepository.findAllByUserAndYearAndSemester(user, year, semester).stream()
+                .map(g -> new TimetableGroupResponse(g.getId(), g.getName(), g.getIsPrimary()))
+                .collect(Collectors.toList());
+    }
+
+    public List<TimetableCourseResponse> getTimetableDetails(String email, Long timetableId) {
+        User user = userRepository.findBySchoolEmailOrThrow(email);
+        TimetableGroup group = groupRepository.findByIdAndUser(timetableId, user)
+                .orElseThrow(() -> DataNotFoundException.from("시간표", timetableId));
+
+        return timetableRepository.findAllByTimetableGroup(group).stream()
+                .map(t -> {
+                    Course c = t.getCourse();
+                    Room r = c.getRoom();
+                    Building b = r.getBuilding();
+                    return new TimetableCourseResponse(
+                            c.getId(), c.getCourseName(), c.getDayOfWeek(),
+                            c.getStartTime(), c.getEndTime(),
+                            r.getName(), b.getName(), b.getCode(), t.getColor()
+                    );
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void syncTimetable(String email, Long timetableId, TimetableSyncRequest request) {
+        User user = userRepository.findBySchoolEmailOrThrow(email);
+        TimetableGroup group = groupRepository.findByIdAndUser(timetableId, user)
+                .orElseThrow(() -> DataNotFoundException.from("시간표", timetableId));
+
+        // 1. 기존 내역 삭제
+        timetableRepository.deleteAllByTimetableGroup(group);
+
+        // 2. 새로운 강의 데이터 로드 및 중복 검증
+        List<Timetable> newTimetables = new ArrayList<>();
+        for (var req : request.courses()) {
+            Course course = courseRepository.findById(req.courseId())
+                    .orElseThrow(() -> DataNotFoundException.from("강의", req.courseId()));
+            
+            // 시간 중복 체크
+            validateOverlap(newTimetables, course);
+
+            newTimetables.add(Timetable.builder()
+                    .course(course)
+                    .timetableGroup(group)
+                    .color(req.color())
+                    .build());
+        }
+
+        timetableRepository.saveAll(newTimetables);
+    }
+
+    public Page<TimetableCourseResponse> searchCourses(Integer year, Integer semester, String keyword, Pageable pageable) {
+        return courseRepository.searchCourses(year, semester, keyword, pageable)
+                .map(c -> {
+                    Room r = c.getRoom();
+                    Building b = r.getBuilding();
+                    return new TimetableCourseResponse(
+                            c.getId(), c.getCourseName(), c.getDayOfWeek(),
+                            c.getStartTime(), c.getEndTime(),
+                            r.getName(), b.getName(), b.getCode(), null
+                    );
+                });
+    }
+
+    private void validateOverlap(List<Timetable> existing, Course target) {
+        for (Timetable t : existing) {
+            Course c = t.getCourse();
+            if (c.getDayOfWeek() == target.getDayOfWeek()) {
+                // (StartA < EndB) && (EndA > StartB) 이면 겹침
+                if (target.getStartTime().isBefore(c.getEndTime()) && 
+                    target.getEndTime().isAfter(c.getStartTime())) {
+                    String message = String.format("강의 시간이 겹칩니다: %s & %s", c.getCourseName(), target.getCourseName());
+                    throw new BadRequestException(message, message);
+                }
+            }
+        }
+    }
+}

--- a/zoopick_dump.sql
+++ b/zoopick_dump.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict iy4NXqJLE04WaVbAXkFSynTIPUX1VFkLGywRajAcxAxWEWglDsme3gweu4uml74
+\restrict knEphJBtBaU0XtNnamEd80jQUqm15GSDwBEkbzT3sCe6eNhHkym4htiMgY1Pc8T
 
 -- Dumped from database version 18.3
 -- Dumped by pg_dump version 18.3
@@ -581,7 +581,11 @@ CREATE TABLE zoopick.item_matches (
                                       id bigint NOT NULL,
                                       lost_item_id bigint NOT NULL,
                                       found_item_id bigint NOT NULL,
-                                      score real NOT NULL,
+                                      score_category real,
+                                      score_visual real,
+                                      score_spatial real,
+                                      score_temporal real,
+                                      score_total real NOT NULL,
                                       status zoopick.match_status DEFAULT 'CANDIDATE'::zoopick.match_status NOT NULL,
                                       created_at timestamp without time zone DEFAULT now() NOT NULL,
                                       updated_at timestamp without time zone
@@ -1042,12 +1046,11 @@ ALTER TABLE ONLY zoopick.users ALTER COLUMN id SET DEFAULT nextval('zoopick.user
 --
 
 COPY zoopick.buildings (id, name, code, latitude, longitude) FROM stdin;
-1	??怨듯븰愿	ENG5	37.2236	127.1878
-2	??怨듯븰愿	ENG1	37.224	127.1882
-3	?⑤컯愿	HBK	37.2233	127.1872
-4	李⑥꽭?怨쇳븰愿	NSCI	37.2228	127.1885
-5	李쎌“?덉닠愿	ART	37.1232	127.321321
-6	??怨듯븰愿	ENG2	37.2245	127.189
+1	??怨듯븰愿	ENG5	37.221984	127.187616
+2	??怨듯븰愿	ENG2	37.221523	127.186795
+3	??怨듯븰愿	ENG1	37.222482	127.187167
+4	?⑤컯愿	HBK	37.221122	127.18861
+5	李쎌“?덉닠愿	ART	37.222838	127.189279
 \.
 
 
@@ -1104,18 +1107,31 @@ COPY zoopick.chat_rooms (id, item_id, owner_id, finder_id, status, resolved_by, 
 --
 
 COPY zoopick.courses (id, course_name, room_id, year, semester, day_of_week, start_time, end_time) FROM stdin;
-1	罹≪뒪?ㅻ뵒?먯씤1	1	2026	1	MON	09:00:00	12:00:00
-2	?댁쁺泥댁젣	2	2026	1	MON	13:30:00	15:00:00
-3	而댄벂?곕꽕?몄썙??3	2026	1	TUE	10:30:00	12:00:00
-4	?멸났吏?κ컻濡?1	2026	1	WED	13:30:00	16:30:00
-5	?곗씠?곕쿋?댁뒪	2	2026	1	THU	09:00:00	10:30:00
-6	?뚰봽?몄썾?닿났??3	2026	1	FRI	13:30:00	15:00:00
-7	?뚭퀬由ъ쬁	1	2026	1	MON	15:00:00	16:30:00
-8	?먮즺援ъ“	2	2026	1	TUE	13:30:00	15:00:00
-9	誘몄쟻遺꾪븰	6	2026	1	MON	09:00:00	10:30:00
-10	?쇰컲臾쇰━	5	2026	1	TUE	15:00:00	16:30:00
-11	援먯뼇?곸뼱	6	2026	1	WED	13:30:00	15:00:00
-12	??숆뎅??4	2026	1	FRI	09:00:00	10:30:00
+1	4李⑥궛?낇쁺紐낃낵誘몃옒?ы쉶吏꾨줈?좏깮	1	2026	1	MON	13:00:00	14:50:00
+2	怨듯븰?섑븰1	2	2026	1	FRI	09:00:00	11:50:00
+3	湲?곌린	3	2026	1	MON	13:00:00	14:50:00
+4	湲?곌린	3	2026	1	WED	14:00:00	14:50:00
+5	?섍꼍怨쇱씤媛?4	2026	1	TUE	14:00:00	14:50:00
+6	?듦퀎??5	2026	1	MON	10:00:00	12:50:00
+7	?쇰컲?앸Ъ??6	2026	1	THU	13:00:00	14:50:00
+8	4李⑥궛?낇쁺紐낃낵誘몃옒?ы쉶吏꾨줈?좏깮	7	2026	1	WED	10:00:00	11:50:00
+9	而댄벂?고븯?쒖썾??7	2026	1	TUE	14:00:00	16:50:00
+10	罹≪뒪?ㅻ뵒?먯씤	8	2026	1	MON	13:00:00	15:50:00
+11	?댁쁺泥댁젣	9	2026	1	MON	10:00:00	11:50:00
+12	?댁쁺泥댁젣	9	2026	1	WED	10:00:00	10:50:00
+13	怨듯븰?섑븰1	9	2026	1	TUE	13:00:00	14:50:00
+14	怨듯븰?섑븰1	9	2026	1	THU	13:00:00	13:50:00
+15	?쒖뒪?쒗겢?쇱슦?쒕낫??10	2026	1	THU	13:00:00	15:50:00
+16	湲곌퀎?숈뒿	10	2026	1	MON	13:00:00	14:50:00
+17	湲곌퀎?숈뒿	10	2026	1	WED	13:00:00	13:50:00
+18	諛쒗몴??좎쓽	11	2026	1	MON	14:00:00	15:50:00
+19	諛쒗몴??좎쓽	11	2026	1	WED	14:00:00	15:50:00
+20	誘몄쟻遺꾪븰1	12	2026	1	MON	11:00:00	12:50:00
+21	?곸뼱1	13	2026	1	TUE	11:00:00	11:50:00
+22	?곸뼱1	13	2026	1	THU	11:00:00	11:50:00
+23	?멸퀎?곹솕??14	2026	1	TUE	11:00:00	13:50:00
+24	援먯뼇諛붾몣	15	2026	1	TUE	13:00:00	14:50:00
+25	裕ㅼ?而ш컻濡?16	2026	1	FRI	13:00:00	15:50:00
 \.
 
 
@@ -1123,7 +1139,7 @@ COPY zoopick.courses (id, course_name, room_id, year, semester, day_of_week, sta
 -- Data for Name: item_matches; Type: TABLE DATA; Schema: zoopick; Owner: postgres
 --
 
-COPY zoopick.item_matches (id, lost_item_id, found_item_id, score, status, created_at, updated_at) FROM stdin;
+COPY zoopick.item_matches (id, lost_item_id, found_item_id, score_category, score_visual, score_spatial, score_temporal, score_total, status, created_at, updated_at) FROM stdin;
 \.
 
 
@@ -1132,17 +1148,6 @@ COPY zoopick.item_matches (id, lost_item_id, found_item_id, score, status, creat
 --
 
 COPY zoopick.item_posts (id, title, description, item_id, user_id, created_at) FROM stdin;
-1	寃??媛諛?5怨듯븰愿?먯꽌 二쇱썱?듬땲??1	5	2026-05-07 21:06:26.535971
-2	寃????ш컖媛諛?5怨?4痢?2	5	2026-05-07 21:39:00.293706
-3	踰좎씠吏 ?꾪넻	5怨?3	5	2026-05-07 21:40:35.781513
-4	?꾪넻 踰좎씠吏	踰좎씠吏	4	5	2026-05-07 21:57:53.143895
-5	留쏇룿	?꾩삤	5	5	2026-05-07 22:33:05.275236
-6	?먮Ъ????6	5	2026-05-07 22:48:51.087485
-7	寃? 媛諛?寃?媛諛⑹엫??7	5	2026-05-08 01:32:43.018062
-8	?ъ떎? 怨좎뼇?댁엫	?곕━吏?怨좎뼇??洹?ъ?	8	5	2026-05-08 01:47:45.551963
-9	寃???댁뼱???댁뼅?몄슦	9	5	2026-05-08 02:21:46.624059
-10	?ㅻ뱶????10	5	2026-05-08 16:56:14.533686
-11	媛쒕뀗???껋뼱踰꾨졇?듬땲??萸?11	5	2026-05-08 16:57:06.344456
 \.
 
 
@@ -1151,18 +1156,6 @@ COPY zoopick.item_posts (id, title, description, item_id, user_id, created_at) F
 --
 
 COPY zoopick.items (id, reporter_id, type, status, category, color, embedding, reported_building_id, location_name, reported_at, theft_suspected_at, returned_at, image_url, created_at, updated_at) FROM stdin;
-0	1	LOST	REPORTED	\N	\N	\N	1	5怨듯븰愿 ?대뵒	2026-05-06 01:11:08.911	2026-05-06 01:11:31.039	2026-05-06 01:11:33.44	\N	2026-05-06 01:11:49.298	\N
-1	5	FOUND	REPORTED	\N	\N	\N	1	4痢?5047	2026-05-07 21:06:26.463101	\N	\N	\N	2026-05-07 21:06:26.463101	2026-05-07 21:06:26.463101
-2	5	FOUND	REPORTED	\N	\N	\N	1	5407	2026-05-07 21:39:00.286687	\N	\N	\N	2026-05-07 21:39:00.286687	2026-05-07 21:39:00.286687
-3	5	FOUND	REPORTED	\N	\N	\N	1	4痢?2026-05-07 21:40:35.78051	\N	\N	\N	2026-05-07 21:40:35.78051	2026-05-07 21:40:35.78051
-4	5	FOUND	REPORTED	\N	\N	\N	1	??醫 ?섎씪	2026-05-07 21:57:53.126678	\N	\N	/images/item/33fd817a-d8c3-48ba-8e35-83ef8c517a82.jpg	2026-05-07 21:57:53.126678	2026-05-07 21:57:53.126678
-5	5	FOUND	REPORTED	\N	\N	\N	1	醫 ?섎씪 ?쒕컻	2026-05-07 22:33:05.258713	\N	\N	/images/item/4ac2a45c-7f1e-4275-96e8-c15be3a05fa6.jpg	2026-05-07 22:33:05.258713	2026-05-07 22:33:05.258713
-6	5	FOUND	REPORTED	SMARTPHONE	WHITE	\N	1	4痢?2026-05-07 13:48:12.587	\N	\N	/images/item/fbe58942-8350-4755-a8a8-dafe5e0990d9.jpg	2026-05-07 22:48:51.068954	2026-05-07 22:48:51.068954
-7	5	FOUND	REPORTED	BAG	BLACK	\N	1	4痢?2026-05-07 16:32:12.197	\N	\N	/images/item/bb478d3c-45a0-48c8-9a10-346b727f743c.jpg	2026-05-08 01:32:42.991555	2026-05-08 01:32:42.991555
-8	5	FOUND	REPORTED	PLUSH_TOY	WHITE	\N	3	??2026-05-07 16:46:37.357	\N	\N	/images/item/c4f9dab6-ead8-4ec5-9a4b-4207a8410b8f.jpeg	2026-05-08 01:47:45.548962	2026-05-08 01:47:45.548962
-9	5	FOUND	REPORTED	EARPHONES	BLACK	\N	3		2026-05-07 17:20:57.453	\N	\N	/images/item/0fa46e20-9f07-4c50-bbcb-410586452943.jpeg	2026-05-08 02:21:46.621056	2026-05-08 02:21:46.621056
-10	5	FOUND	REPORTED	EARPHONES	BLACK	\N	1		2026-05-08 07:55:46.582	\N	\N	/images/item/f3a6330b-2d86-4ba3-a104-9ec7bd66c39b.jpeg	2026-05-08 16:56:14.504043	2026-05-08 16:56:14.504043
-11	5	LOST	REPORTED	STUDENT_ID_CARD	WHITE	\N	2	??2026-05-08 07:56:35.035	\N	\N	/images/item/fbc6462a-7b09-450d-a9b6-ae73cb6db89d.png	2026-05-08 16:57:06.343457	2026-05-08 16:57:06.343457
 \.
 
 
@@ -1179,7 +1172,6 @@ COPY zoopick.locker_commands (id, locker_id, command, status, issued_by, created
 --
 
 COPY zoopick.lockers (id, status, current_item_id) FROM stdin;
-1	EMPTY	\N
 \.
 
 
@@ -1196,12 +1188,22 @@ COPY zoopick.notifications (id, user_id, type, payload, read_at, created_at) FRO
 --
 
 COPY zoopick.rooms (id, building_id, name) FROM stdin;
-1	1	Y5407
-2	1	Y5301
-3	2	Y9029
-4	3	Y22217
-5	4	?媛뺣떦
-6	3	?대엺??
+1	3	Y106
+2	3	Y123
+3	3	Y117
+4	2	Y8110
+5	2	Y8107
+6	2	Y8114
+7	1	Y5420
+8	1	Y5441
+9	1	Y5411
+10	1	Y5445
+11	4	Y9501
+12	4	Y9508
+13	4	Y9515
+14	5	Y2237
+15	5	Y2259
+16	5	Y2119
 \.
 
 
@@ -1236,7 +1238,7 @@ COPY zoopick.users (id, school_email, password, nickname, department, grade, fcm
 -- Name: buildings_id_seq; Type: SEQUENCE SET; Schema: zoopick; Owner: postgres
 --
 
-SELECT pg_catalog.setval('zoopick.buildings_id_seq', 6, true);
+SELECT pg_catalog.setval('zoopick.buildings_id_seq', 5, true);
 
 
 --
@@ -1285,7 +1287,7 @@ SELECT pg_catalog.setval('zoopick.chat_rooms_id_seq', 1, false);
 -- Name: courses_id_seq; Type: SEQUENCE SET; Schema: zoopick; Owner: postgres
 --
 
-SELECT pg_catalog.setval('zoopick.courses_id_seq', 12, true);
+SELECT pg_catalog.setval('zoopick.courses_id_seq', 25, true);
 
 
 --
@@ -1299,14 +1301,14 @@ SELECT pg_catalog.setval('zoopick.item_matches_id_seq', 1, false);
 -- Name: item_posts_id_seq; Type: SEQUENCE SET; Schema: zoopick; Owner: postgres
 --
 
-SELECT pg_catalog.setval('zoopick.item_posts_id_seq', 11, true);
+SELECT pg_catalog.setval('zoopick.item_posts_id_seq', 1, false);
 
 
 --
 -- Name: items_id_seq; Type: SEQUENCE SET; Schema: zoopick; Owner: postgres
 --
 
-SELECT pg_catalog.setval('zoopick.items_id_seq', 11, true);
+SELECT pg_catalog.setval('zoopick.items_id_seq', 1, false);
 
 
 --
@@ -1327,7 +1329,7 @@ SELECT pg_catalog.setval('zoopick.notifications_id_seq', 1, false);
 -- Name: rooms_id_seq; Type: SEQUENCE SET; Schema: zoopick; Owner: postgres
 --
 
-SELECT pg_catalog.setval('zoopick.rooms_id_seq', 6, true);
+SELECT pg_catalog.setval('zoopick.rooms_id_seq', 16, true);
 
 
 --
@@ -1590,20 +1592,6 @@ ALTER TABLE ONLY zoopick.users
 ALTER TABLE ONLY zoopick.users
     ADD CONSTRAINT users_school_email_key UNIQUE (school_email);
 
---
--- Name: idx_items_embedding_hnsw; Type: INDEX; Schema: zoopick; Owner: postgres
---
-
-CREATE INDEX idx_items_embedding_hnsw ON zoopick.items USING hnsw (embedding vector_cosine_ops);
-
-
-
---
--- Name: idx_items_filtering; Type: INDEX; Schema: zoopick; Owner: postgres
---
-
-CREATE INDEX idx_items_filtering ON zoopick.items (category, color);
-
 
 --
 -- Name: idx_chatrooms_open; Type: INDEX; Schema: zoopick; Owner: postgres
@@ -1666,6 +1654,13 @@ CREATE INDEX idx_items_building ON zoopick.items USING btree (reported_building_
 --
 
 CREATE INDEX idx_items_created ON zoopick.items USING btree (created_at DESC);
+
+
+--
+-- Name: idx_items_filtering; Type: INDEX; Schema: zoopick; Owner: postgres
+--
+
+CREATE INDEX idx_items_filtering ON zoopick.items USING btree (category, color);
 
 
 --
@@ -1971,5 +1966,5 @@ ALTER TABLE ONLY zoopick.cctv_videos
 -- PostgreSQL database dump complete
 --
 
-\unrestrict iy4NXqJLE04WaVbAXkFSynTIPUX1VFkLGywRajAcxAxWEWglDsme3gweu4uml74
+\unrestrict knEphJBtBaU0XtNnamEd80jQUqm15GSDwBEkbzT3sCe6eNhHkym4htiMgY1Pc8T
 


### PR DESCRIPTION
  1. DB 스키마 및 Entity 개선
   - timetable_groups 테이블 신설: 사용자가 한 학기 내에 여러 시간표를 가질 수 있도록 그룹 계층을
     추가하였습니다. (생성 시 메인 시간표 판별을 위한 is_primary 필드 포함)
   - timetables 테이블 구조 변경:
     - 정규화를 위해 기존 User 직접 참조에서 TimetableGroup 참조 방식으로 변경하였습니다.
     - 사용자가 지정한 강의 블록 색상을 저장하기 위해 color (Hex) 필드를 추가하였습니다.
   - courses 마스터 데이터 유지: 기존 정규 강의 테이블 구조는 그대로 보존하여 안전성을 확보했습니다.       

  2. 신규 API 구현 (TimetableController)
   - POST /api/timetables: 새 시간표 그룹 생성 (해당 학기의 첫 시간표인 경우 자동으로 isPrimary = true     
     할당)
   - GET /api/timetables: 내 시간표 목록(Plan 리스트) 조회
   - GET /api/timetables/{id}: 선택한 시간표의 강의 상세 내역(강의실, 시간, 요일, 색상 등) 조회
   - POST /api/timetables/{id}/sync: 편집된 시간표의 강의 목록과 색상을 DB에 일괄 반영
   - GET /api/courses: 강의 검색용 마스터 데이터 조회 (Pageable 적용)

  3. 주요 비즈니스 로직 (TimetableService)
   - 시간표 일괄 동기화 (Sync):
     - 프론트엔드에서 완성된 시간표의 최종 형태(강의 ID 배열)를 서버로 전송합니다.
     - 서버는 기존 연결된 수강 내역을 모두 지운 후, 새로 전달받은 내역으로 덮어씁니다. (@Transactional     
       적용)
   - 시간 중복(Overlap) 검증:
     - 일괄 저장 로직 수행 시, 전달된 강의들 간에 요일과 시간(LocalTime)이 겹치는지 전수 검사합니다.       
     - 중복 발견 시 프로젝트 표준 예외인 BadRequestException을 발생시켜 안전하게 롤백합니다.
