### PR TITLE
Feat/item match action

### DIFF
--- a/src/main/java/com/zoopick/server/controller/ItemMatchController.java
+++ b/src/main/java/com/zoopick/server/controller/ItemMatchController.java
@@ -50,6 +50,11 @@ public class ItemMatchController {
         return CommonResponse.success(matchId);
     }
 
+    @Operation(summary = "매칭 거절", description = "유저가 아이템의 매칭을 거절합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "매칭 거절"),
+            @ApiResponse(responseCode = "404", description = "매칭을 찾을 수 없음")
+    })
     @PostMapping("/{matchId}/reject")
     public CommonResponse<Long> itemMatchReject(
             @Parameter(description = "매치 id")
@@ -57,7 +62,12 @@ public class ItemMatchController {
         itemMatchService.rejectMatch(matchId);
         return CommonResponse.success(matchId);
     }
-
+    
+    @Operation(summary = "매칭 수동 적용", description = "유저가 아이템의 매칭을 수동 성사시킵니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "매칭 성공"),
+            @ApiResponse(responseCode = "404", description = "매칭을 찾을 수 없음")
+    })
     @PostMapping("/manual")
     public CommonResponse<MatchManualResponse> itemMatchManual(@RequestBody MatchManualRequest request) {
         MatchManualResponse matchManualResponse = itemMatchService.matchManual(request);

--- a/src/main/java/com/zoopick/server/controller/ItemMatchController.java
+++ b/src/main/java/com/zoopick/server/controller/ItemMatchController.java
@@ -1,7 +1,9 @@
 package com.zoopick.server.controller;
 
 import com.zoopick.server.dto.CommonResponse;
-import com.zoopick.server.dto.item.ItemMatchResultResponse;
+import com.zoopick.server.dto.match.ItemMatchResultResponse;
+import com.zoopick.server.dto.match.MatchManualRequest;
+import com.zoopick.server.dto.match.MatchManualResponse;
 import com.zoopick.server.security.UserPrincipal;
 import com.zoopick.server.service.ItemMatchService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,9 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -31,9 +31,36 @@ public class ItemMatchController {
             @ApiResponse(responseCode = "404", description = "매칭을 찾을 수 없음")
     })
     @GetMapping("/me")
-    public CommonResponse<List<ItemMatchResultResponse>> itemMatchingResult(
+    public CommonResponse<List<ItemMatchResultResponse>> itemMatchResult(
             @Parameter(description = "조회할 유저")
             @AuthenticationPrincipal UserPrincipal principal) {
         return CommonResponse.success(itemMatchService.getItemMatchResult(principal.id()));
+    }
+
+    @Operation(summary = "매칭 성사", description = "유저가 아이템의 매칭을 성사시킵니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "매칭 성공"),
+            @ApiResponse(responseCode = "404", description = "매칭을 찾을 수 없음")
+    })
+    @PostMapping("/{matchId}/confirm")
+    public CommonResponse<Long> itemMatchConfirm(
+            @Parameter(description = "매치 id")
+            @PathVariable Long matchId) {
+        itemMatchService.confirmMatch(matchId);
+        return CommonResponse.success(matchId);
+    }
+
+    @PostMapping("/{matchId}/reject")
+    public CommonResponse<Long> itemMatchReject(
+            @Parameter(description = "매치 id")
+            @PathVariable Long matchId) {
+        itemMatchService.rejectMatch(matchId);
+        return CommonResponse.success(matchId);
+    }
+
+    @PostMapping("/manual")
+    public CommonResponse<MatchManualResponse> itemMatchManual(@RequestBody MatchManualRequest request) {
+        MatchManualResponse matchManualResponse = itemMatchService.matchManual(request);
+        return CommonResponse.success(matchManualResponse);
     }
 }

--- a/src/main/java/com/zoopick/server/dto/match/ItemMatchProjection.java
+++ b/src/main/java/com/zoopick/server/dto/match/ItemMatchProjection.java
@@ -1,4 +1,4 @@
-package com.zoopick.server.dto.item;
+package com.zoopick.server.dto.match;
 
 public interface ItemMatchProjection {
     String getMatchId();

--- a/src/main/java/com/zoopick/server/dto/match/ItemMatchResultResponse.java
+++ b/src/main/java/com/zoopick/server/dto/match/ItemMatchResultResponse.java
@@ -1,4 +1,4 @@
-package com.zoopick.server.dto.item;
+package com.zoopick.server.dto.match;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.zoopick.server.entity.MatchStatus;

--- a/src/main/java/com/zoopick/server/dto/match/MatchManualRequest.java
+++ b/src/main/java/com/zoopick/server/dto/match/MatchManualRequest.java
@@ -1,0 +1,20 @@
+package com.zoopick.server.dto.match;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class MatchManualRequest {
+    @NotNull
+    @JsonProperty("lost_item_id")
+    Long lostItemId;
+    @NotNull
+    @JsonProperty("found_item_id")
+    Long foundItemId;
+
+}

--- a/src/main/java/com/zoopick/server/dto/match/MatchManualResponse.java
+++ b/src/main/java/com/zoopick/server/dto/match/MatchManualResponse.java
@@ -1,0 +1,22 @@
+package com.zoopick.server.dto.match;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.zoopick.server.entity.MatchManualType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class MatchManualResponse {
+    @NotNull
+    @JsonProperty("match_id")
+    private Long matchId;
+    @NotNull
+    @JsonProperty("match_manual_type")
+    private MatchManualType matchManualType;
+    @JsonProperty("locker_id")
+    private Long lockerId;
+}

--- a/src/main/java/com/zoopick/server/dto/match/SimilarItemProjection.java
+++ b/src/main/java/com/zoopick/server/dto/match/SimilarItemProjection.java
@@ -1,4 +1,4 @@
-package com.zoopick.server.dto.item;
+package com.zoopick.server.dto.match;
 
 public interface SimilarItemProjection {
     Long getItemId();

--- a/src/main/java/com/zoopick/server/dto/match/SimilarItemResult.java
+++ b/src/main/java/com/zoopick/server/dto/match/SimilarItemResult.java
@@ -1,4 +1,4 @@
-package com.zoopick.server.dto.item;
+package com.zoopick.server.dto.match;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/zoopick/server/entity/MatchManualType.java
+++ b/src/main/java/com/zoopick/server/entity/MatchManualType.java
@@ -1,0 +1,6 @@
+package com.zoopick.server.entity;
+
+public enum MatchManualType {
+    LOCKER,
+    CHAT;
+}

--- a/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
@@ -4,6 +4,7 @@ import com.zoopick.server.dto.match.ItemMatchProjection;
 import com.zoopick.server.dto.match.SimilarItemProjection;
 import com.zoopick.server.entity.Item;
 import com.zoopick.server.entity.ItemMatch;
+import com.zoopick.server.entity.MatchStatus;
 import com.zoopick.server.exception.DataNotFoundException;
 import org.springframework.data.domain.Vector;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -84,4 +85,8 @@ public interface ItemMatchRepository extends JpaRepository<ItemMatch, Long> {
     int rejectOthersByLostItem(@Param("matchId") Long matchId,
                                 @Param("lostItemId") Long lostItemId,
                                 @Param("foundItemId") Long foundItemId);
+
+    // CONFIRMED된 매칭이 있는지 확인
+    boolean existsByLostItemAndStatus(Item lostItem, MatchStatus status);
+    boolean existsByFoundItemAndStatus(Item foundItem, MatchStatus status);
 }

--- a/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
@@ -1,11 +1,13 @@
 package com.zoopick.server.repository;
 
-import com.zoopick.server.dto.item.ItemMatchProjection;
-import com.zoopick.server.dto.item.SimilarItemProjection;
+import com.zoopick.server.dto.match.ItemMatchProjection;
+import com.zoopick.server.dto.match.SimilarItemProjection;
 import com.zoopick.server.entity.Item;
 import com.zoopick.server.entity.ItemMatch;
+import com.zoopick.server.exception.DataNotFoundException;
 import org.springframework.data.domain.Vector;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -15,6 +17,11 @@ import java.util.List;
 
 @Repository
 public interface ItemMatchRepository extends JpaRepository<ItemMatch, Long> {
+
+
+    default ItemMatch findByIdOrThrow(Long id) {
+        return findById(id).orElseThrow(() -> DataNotFoundException.from("매칭", id));
+    }
 
     @Query(value = """
     SELECT *
@@ -65,4 +72,16 @@ public interface ItemMatchRepository extends JpaRepository<ItemMatch, Long> {
     ORDER BY m.score desc -- 내림차순으로 뽑음
     """, nativeQuery = true)
     List<ItemMatchProjection> itemMatchesByLostItem(@Param("userId") Long userId);
+
+    // 매칭 컨펌된 것 제외 모든 물품을 다 rejected
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+    UPDATE item_matches SET status = 'REJECTED'
+    WHERE (lost_item_id = :lostItemId OR found_item_id = :foundItemId)
+    AND id != :matchId
+    AND status IN ('CANDIDATE', 'NOTIFIED')
+""", nativeQuery = true)
+    int rejectOthersByLostItem(@Param("matchId") Long matchId,
+                                @Param("lostItemId") Long lostItemId,
+                                @Param("foundItemId") Long foundItemId);
 }

--- a/src/main/java/com/zoopick/server/repository/ItemPostRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ItemPostRepository.java
@@ -1,10 +1,7 @@
 package com.zoopick.server.repository;
 
 import com.zoopick.server.dto.item.ItemPostFilter;
-import com.zoopick.server.entity.ItemCategory;
-import com.zoopick.server.entity.ItemColor;
-import com.zoopick.server.entity.ItemPost;
-import com.zoopick.server.entity.ItemStatus;
+import com.zoopick.server.entity.*;
 import com.zoopick.server.exception.DataNotFoundException;
 import jakarta.persistence.criteria.Join;
 import org.springframework.data.jpa.domain.Specification;
@@ -54,4 +51,5 @@ public interface ItemPostRepository extends JpaRepository<ItemPost, Long>, JpaSp
     }
 
     long countByUserId(Long userId);
+    ItemPost findByItem(Item item);
 }

--- a/src/main/java/com/zoopick/server/repository/LockerRepository.java
+++ b/src/main/java/com/zoopick/server/repository/LockerRepository.java
@@ -1,7 +1,9 @@
 package com.zoopick.server.repository;
 
+import com.zoopick.server.entity.Item;
 import com.zoopick.server.entity.Locker;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LockerRepository extends JpaRepository<Locker, Long> {
+    Locker findLockerByCurrentItem(Item currentItem);
 }

--- a/src/main/java/com/zoopick/server/service/ItemMatchService.java
+++ b/src/main/java/com/zoopick/server/service/ItemMatchService.java
@@ -1,14 +1,20 @@
 package com.zoopick.server.service;
 
+import com.google.firebase.messaging.FirebaseMessagingException;
 import com.zoopick.server.dto.match.ItemMatchResultResponse;
 import com.zoopick.server.dto.match.MatchManualRequest;
 import com.zoopick.server.dto.match.MatchManualResponse;
 import com.zoopick.server.dto.match.SimilarItemResult;
 import com.zoopick.server.entity.*;
 import com.zoopick.server.exception.BadRequestException;
+import com.zoopick.server.exception.DataNotFoundException;
 import com.zoopick.server.repository.ItemMatchRepository;
+import com.zoopick.server.repository.ItemPostRepository;
 import com.zoopick.server.repository.ItemRepository;
 import com.zoopick.server.repository.LockerRepository;
+import com.zoopick.server.service.notification.payload.MatchFoundPayload;
+import com.zoopick.server.service.notification.SendNotificationCommand;
+import com.zoopick.server.service.notification.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,6 +32,8 @@ public class ItemMatchService {
     private final ItemRepository itemRepository;
     private final ItemMatchRepository itemMatchRepository;
     private final LockerRepository lockerRepository;
+    private final NotificationService notificationService;
+    private final ItemPostRepository itemPostRepository;
     @Value("${zoopick.similarity.threshold}")
     private float similarityThreshold;
     public void createMatch(Long itemId) {
@@ -48,16 +56,21 @@ public class ItemMatchService {
                 // 게시글에 올라온 아이템이 LOST라면 lostItem에, FOUND라면 foundItem에
                 Item lostItem = targetItem.getType() == ItemType.LOST ? targetItem : foundItemInDb;
                 Item foundItem = targetItem.getType() == ItemType.LOST ? foundItemInDb : targetItem;
-                ItemMatch itemMatch = ItemMatch
-                        .builder()
-                        .score((float) similarItemResult.getScore())
-                        .lostItem(lostItem)
-                        .foundItem(foundItem)
-                        .status(MatchStatus.CANDIDATE)
-                        .build();
                 // 중복 저장 방지
-                if (!itemMatchRepository.existsByLostItemAndFoundItem(lostItem, foundItem))
-                    itemMatchRepository.save(itemMatch);
+                if (!itemMatchRepository.existsByLostItemAndFoundItem(lostItem, foundItem)) {
+                    ItemMatch itemMatch = ItemMatch
+                            .builder()
+                            .score((float) similarItemResult.getScore())
+                            .lostItem(lostItem)
+                            .foundItem(foundItem)
+                            .status(MatchStatus.CANDIDATE)
+                            .build();
+                    ItemMatch savedMatch = itemMatchRepository.save(itemMatch);
+                    boolean isSent = sendMatchNotification(lostItem, foundItem, savedMatch);
+                    if (isSent) {
+                        savedMatch.setStatus(MatchStatus.NOTIFIED);
+                    }
+                }
             }
         }
         else log.warn("매칭된 아이템이 없습니다.");
@@ -138,6 +151,26 @@ public class ItemMatchService {
                     .matchId(itemMatch.getId())
                     .matchManualType(MatchManualType.CHAT)
                     .build();
+        }
+    }
+
+    private boolean sendMatchNotification(Item lostItem, Item foundItem, ItemMatch match) {
+        String title = itemPostRepository.findByItem(lostItem).getTitle();
+        String location = foundItem.getLocationName();
+        try {
+            notificationService.send(lostItem.getReporter(), new SendNotificationCommand(
+                    "분실물 발견",
+                    "회원님이 등록한 %s와 유사한 물건이 %s에서 발견됐어요.".formatted(title, location),
+                    new MatchFoundPayload(lostItem.getId(), match.getId(), match.getScore())
+            ));
+            return true;
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM 전송 실패 (matchId: {}): {}", match.getId(), e.getMessage());
+            return false;
+        } catch (DataNotFoundException e) {
+            // FCM 토큰 없는 유저
+            log.warn("FCM 토큰 없음 (matchId: {}, userId: {})", match.getId(), lostItem.getReporter().getId());
+            return false;
         }
     }
 }

--- a/src/main/java/com/zoopick/server/service/ItemMatchService.java
+++ b/src/main/java/com/zoopick/server/service/ItemMatchService.java
@@ -36,6 +36,7 @@ public class ItemMatchService {
     private final ItemPostRepository itemPostRepository;
     @Value("${zoopick.similarity.threshold}")
     private float similarityThreshold;
+
     public void createMatch(Long itemId) {
         log.info("매칭 시작 ID: {}", itemId);
         Item targetItem = itemRepository.findByIdOrThrow(itemId); // 게시글이 올라간 아이템
@@ -49,31 +50,33 @@ public class ItemMatchService {
                 .stream()
                 .map(p -> new SimilarItemResult(p.getItemId(), p.getScore()))
                 .toList();
-        if (!similarItems.isEmpty()) {
-            for (SimilarItemResult similarItemResult : similarItems) {
-                Item foundItemInDb = itemRepository.findByIdOrThrow(similarItemResult.getItemId());
-                log.info("매칭된 아이템 ID: {}", foundItemInDb.getId());
-                // 게시글에 올라온 아이템이 LOST라면 lostItem에, FOUND라면 foundItem에
-                Item lostItem = targetItem.getType() == ItemType.LOST ? targetItem : foundItemInDb;
-                Item foundItem = targetItem.getType() == ItemType.LOST ? foundItemInDb : targetItem;
-                // 중복 저장 방지
-                if (!itemMatchRepository.existsByLostItemAndFoundItem(lostItem, foundItem)) {
-                    ItemMatch itemMatch = ItemMatch
-                            .builder()
-                            .score((float) similarItemResult.getScore())
-                            .lostItem(lostItem)
-                            .foundItem(foundItem)
-                            .status(MatchStatus.CANDIDATE)
-                            .build();
-                    ItemMatch savedMatch = itemMatchRepository.save(itemMatch);
-                    boolean isSent = sendMatchNotification(lostItem, foundItem, savedMatch);
-                    if (isSent) {
-                        savedMatch.setStatus(MatchStatus.NOTIFIED);
-                    }
+
+        if (similarItems.isEmpty()) {
+            log.warn("매칭된 아이템이 없습니다.");
+            return;
+        }
+        for (SimilarItemResult similarItemResult : similarItems) {
+            Item foundItemInDb = itemRepository.findByIdOrThrow(similarItemResult.getItemId());
+            log.info("매칭된 아이템 ID: {}", foundItemInDb.getId());
+            // 게시글에 올라온 아이템이 LOST라면 lostItem에, FOUND라면 foundItem에
+            Item lostItem = targetItem.getType() == ItemType.LOST ? targetItem : foundItemInDb;
+            Item foundItem = targetItem.getType() == ItemType.LOST ? foundItemInDb : targetItem;
+            // 중복 저장 방지
+            if (!itemMatchRepository.existsByLostItemAndFoundItem(lostItem, foundItem)) {
+                ItemMatch itemMatch = ItemMatch
+                        .builder()
+                        .score((float) similarItemResult.getScore())
+                        .lostItem(lostItem)
+                        .foundItem(foundItem)
+                        .status(MatchStatus.CANDIDATE)
+                        .build();
+                ItemMatch savedMatch = itemMatchRepository.save(itemMatch);
+                boolean isSent = sendMatchNotification(lostItem, foundItem, savedMatch);
+                if (isSent) {
+                    savedMatch.setStatus(MatchStatus.NOTIFIED);
                 }
             }
         }
-        else log.warn("매칭된 아이템이 없습니다.");
         log.info("매칭 종료 ID: {}", targetItem.getId());
     }
 
@@ -100,10 +103,12 @@ public class ItemMatchService {
         Item lostItem = itemMatch.getLostItem();
         Item foundItem = itemMatch.getFoundItem();
 
+        validateNotAlreadyConfirmed(lostItem, foundItem);
+
         lostItem.setStatus(ItemStatus.MATCHED);
         foundItem.setStatus(ItemStatus.MATCHED);
-
         itemMatch.setStatus(MatchStatus.CONFIRMED);
+        itemMatchRepository.rejectOthersByLostItem(matchId, lostItem.getId(), foundItem.getId());
         log.info("매칭 CONFIRMED ID: {}", matchId);
     }
 
@@ -121,34 +126,30 @@ public class ItemMatchService {
         if (itemMatchRepository.existsByLostItemAndFoundItem(lostItem, foundItem)) {
             throw new BadRequestException("이미 진행중인 매칭입니다.");
         }
-        if (itemMatchRepository.existsByLostItemAndStatus(lostItem, MatchStatus.CONFIRMED) ||
-                itemMatchRepository.existsByFoundItemAndStatus(foundItem, MatchStatus.CONFIRMED)) {
-            throw new BadRequestException("이미 주인을 찾은 물품이 있습니다.");
-        }
+        validateNotAlreadyConfirmed(lostItem, foundItem);
 
-        ItemMatch itemMatch = ItemMatch.builder() //새로운 매칭 생성
+        ItemMatch savedMatch = itemMatchRepository.save(ItemMatch.builder() // 새로운 매칭
                 .lostItem(lostItem)
                 .foundItem(foundItem)
                 .score(1.0f)
                 .status(MatchStatus.CONFIRMED)
-                .build();
-        itemMatchRepository.save(itemMatch);
-        itemMatchRepository.rejectOthersByLostItem(itemMatch.getId(), lostItem.getId(), foundItem.getId());
-        log.info("매칭 저장 완료 ID: {}", itemMatch.getId());
+                .build());
+        itemMatchRepository.rejectOthersByLostItem(savedMatch.getId(), lostItem.getId(), foundItem.getId());
+        log.info("매칭 저장 완료 ID: {}", savedMatch.getId());
 
         //LOCKER, CHAT 분기
         if (foundItem.getStatus().equals(ItemStatus.IN_LOCKER)) {
             Locker locker = lockerRepository.findLockerByCurrentItem(foundItem);
             log.info("매칭 LOCKER {} <-> {}", request.getLostItemId(), request.getFoundItemId());
             return MatchManualResponse.builder()
-                    .matchId(itemMatch.getId())
+                    .matchId(savedMatch.getId())
                     .matchManualType(MatchManualType.LOCKER)
                     .lockerId(locker.getId())
                     .build();
         } else {
             log.info("매칭 CHAT {} <-> {}", request.getLostItemId(), request.getFoundItemId());
             return MatchManualResponse.builder()
-                    .matchId(itemMatch.getId())
+                    .matchId(savedMatch.getId())
                     .matchManualType(MatchManualType.CHAT)
                     .build();
         }
@@ -171,6 +172,13 @@ public class ItemMatchService {
             // FCM 토큰 없는 유저
             log.warn("FCM 토큰 없음 (matchId: {}, userId: {})", match.getId(), lostItem.getReporter().getId());
             return false;
+        }
+    }
+
+    private void validateNotAlreadyConfirmed(Item lostItem, Item foundItem) {
+        if (itemMatchRepository.existsByLostItemAndStatus(lostItem, MatchStatus.CONFIRMED) ||
+                itemMatchRepository.existsByFoundItemAndStatus(foundItem, MatchStatus.CONFIRMED)) {
+            throw new BadRequestException("이미 주인을 찾은 물품이 있습니다.");
         }
     }
 }

--- a/src/main/java/com/zoopick/server/service/ItemMatchService.java
+++ b/src/main/java/com/zoopick/server/service/ItemMatchService.java
@@ -162,7 +162,7 @@ public class ItemMatchService {
             notificationService.send(lostItem.getReporter(), new SendNotificationCommand(
                     "분실물 발견",
                     "회원님이 등록한 %s와 유사한 물건이 %s에서 발견됐어요.".formatted(title, location),
-                    new MatchFoundPayload(lostItem.getId(), match.getId(), match.getScore())
+                    MatchFoundPayload.of(lostItem, match)
             ));
             return true;
         } catch (FirebaseMessagingException e) {

--- a/src/main/java/com/zoopick/server/service/ItemMatchService.java
+++ b/src/main/java/com/zoopick/server/service/ItemMatchService.java
@@ -1,13 +1,14 @@
 package com.zoopick.server.service;
 
-import com.zoopick.server.dto.item.ItemMatchResultResponse;
-import com.zoopick.server.dto.item.SimilarItemResult;
-import com.zoopick.server.entity.Item;
-import com.zoopick.server.entity.ItemMatch;
-import com.zoopick.server.entity.ItemType;
-import com.zoopick.server.entity.MatchStatus;
+import com.zoopick.server.dto.match.ItemMatchResultResponse;
+import com.zoopick.server.dto.match.MatchManualRequest;
+import com.zoopick.server.dto.match.MatchManualResponse;
+import com.zoopick.server.dto.match.SimilarItemResult;
+import com.zoopick.server.entity.*;
+import com.zoopick.server.exception.BadRequestException;
 import com.zoopick.server.repository.ItemMatchRepository;
 import com.zoopick.server.repository.ItemRepository;
+import com.zoopick.server.repository.LockerRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,6 +25,7 @@ import java.util.List;
 public class ItemMatchService {
     private final ItemRepository itemRepository;
     private final ItemMatchRepository itemMatchRepository;
+    private final LockerRepository lockerRepository;
     @Value("${zoopick.similarity.threshold}")
     private float similarityThreshold;
     public void createMatch(Long itemId) {
@@ -78,5 +80,64 @@ public class ItemMatchService {
                         MatchStatus.valueOf(p.getStatus())
                 ))
                 .toList();
+    }
+
+    public void confirmMatch(Long matchId) {
+        ItemMatch itemMatch = itemMatchRepository.findByIdOrThrow(matchId);
+        Item lostItem = itemMatch.getLostItem();
+        Item foundItem = itemMatch.getFoundItem();
+
+        lostItem.setStatus(ItemStatus.MATCHED);
+        foundItem.setStatus(ItemStatus.MATCHED);
+
+        itemMatch.setStatus(MatchStatus.CONFIRMED);
+        log.info("매칭 CONFIRMED ID: {}", matchId);
+    }
+
+    public void rejectMatch(Long matchId) {
+        ItemMatch itemMatch = itemMatchRepository.findByIdOrThrow(matchId);
+        itemMatch.setStatus(MatchStatus.REJECTED);
+        log.info("매칭 REJECTED ID: {}", matchId);
+    }
+
+    public MatchManualResponse matchManual(MatchManualRequest request) {
+        log.info("수동 매칭 시작: {} <-> {}", request.getLostItemId(), request.getFoundItemId());
+        Item lostItem = itemRepository.findByIdOrThrow(request.getLostItemId());
+        Item foundItem = itemRepository.findByIdOrThrow(request.getFoundItemId());
+
+        if (itemMatchRepository.existsByLostItemAndFoundItem(lostItem, foundItem)) {
+            throw new BadRequestException("이미 진행중인 매칭입니다.");
+        }
+        if (itemMatchRepository.existsByLostItemAndStatus(lostItem, MatchStatus.CONFIRMED) ||
+                itemMatchRepository.existsByFoundItemAndStatus(foundItem, MatchStatus.CONFIRMED)) {
+            throw new BadRequestException("이미 주인을 찾은 물품이 있습니다.");
+        }
+
+        ItemMatch itemMatch = ItemMatch.builder() //새로운 매칭 생성
+                .lostItem(lostItem)
+                .foundItem(foundItem)
+                .score(1.0f)
+                .status(MatchStatus.CONFIRMED)
+                .build();
+        itemMatchRepository.save(itemMatch);
+        itemMatchRepository.rejectOthersByLostItem(itemMatch.getId(), lostItem.getId(), foundItem.getId());
+        log.info("매칭 저장 완료 ID: {}", itemMatch.getId());
+
+        //LOCKER, CHAT 분기
+        if (foundItem.getStatus().equals(ItemStatus.IN_LOCKER)) {
+            Locker locker = lockerRepository.findLockerByCurrentItem(foundItem);
+            log.info("매칭 LOCKER {} <-> {}", request.getLostItemId(), request.getFoundItemId());
+            return MatchManualResponse.builder()
+                    .matchId(itemMatch.getId())
+                    .matchManualType(MatchManualType.LOCKER)
+                    .lockerId(locker.getId())
+                    .build();
+        } else {
+            log.info("매칭 CHAT {} <-> {}", request.getLostItemId(), request.getFoundItemId());
+            return MatchManualResponse.builder()
+                    .matchId(itemMatch.getId())
+                    .matchManualType(MatchManualType.CHAT)
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/zoopick/server/service/VisionService.java
+++ b/src/main/java/com/zoopick/server/service/VisionService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.client.RestClient;
@@ -33,6 +34,7 @@ public class VisionService {
         analyzeImage(event.itemId());
     }
 
+    @Transactional
     public void analyzeImage(Long itemId) {
         log.info("전달된 아이템 ID: {}", itemId);
         Item item = itemRepository.findById(itemId).orElseThrow(() -> new EntityNotFoundException("아이템을 찾을 수 없습니다."));
@@ -55,7 +57,6 @@ public class VisionService {
             item.setCategory(response.getCategory());
             item.setColor(response.getColor());
             item.setEmbedding(response.getEmbedding());
-            itemRepository.save(item);
             itemMatchService.createMatch(item.getId());
         } catch (BadRequestException | DataNotFoundException e) {
             throw e;

--- a/src/main/java/com/zoopick/server/service/VisionService.java
+++ b/src/main/java/com/zoopick/server/service/VisionService.java
@@ -57,6 +57,7 @@ public class VisionService {
             item.setCategory(response.getCategory());
             item.setColor(response.getColor());
             item.setEmbedding(response.getEmbedding());
+            itemRepository.save(item);
             itemMatchService.createMatch(item.getId());
         } catch (BadRequestException | DataNotFoundException e) {
             throw e;


### PR DESCRIPTION
## 📝 Description
분실물과 습득물 간의 매칭 확정, 거절 및 관리자용 수동 매칭 기능을 구현하고 관련 DTO 구조를 개선했습니다.

---

## 🛠 Changes

### 1. 매칭 프로세스 고도화 및 API 추가
* **매칭 확정/거절 API 구현**: `POST /api/matches/{matchId}/confirm` 및 `reject` API를 추가하여 유저가 직접 매칭 여부를 결정할 수 있도록 했습니다.
* **수동 매칭 기능 구현**: 분실물 ID와 습득물 ID를 직접 연결할 수 있는 `POST /api/matches/manual` API를 구현했습니다.
* **상태 변경 로직**: 매칭 확정 시 관련 아이템의 상태를 `MATCHED`로 변경하고, 해당 아이템과 연결된 다른 대기 상태(`CANDIDATE`, `NOTIFIED`)의 매칭들을 자동으로 `REJECTED` 처리하는 로직을 추가했습니다.
* **매칭 알림 연동**: `ItemMatchService`에서 유사 아이템 발견 시 FCM을 통해 유저에게 알림을 발송하고, 발송 성공 시 매칭 상태를 `NOTIFIED`로 갱신합니다.

### 2. 리팩토링 및 버그 수정
* **DTO 패키지 구조 개선**: `dto.item`에 혼재되어 있던 매칭 관련 DTO 및 Projection 클래스들을 `dto.match` 패키지로 이동하여 도메인 간 책임을 분리했습니다.
* **데이터 정합성 검증**: 이미 매칭이 완료된 아이템에 대해 중복 매칭이 발생하지 않도록 `validateNotAlreadyConfirmed` 검증 로직을 추가했습니다.
* **Transactional 추가**: `VisionService.analyzeImage` 메서드에 `@Transactional`을 추가하여 이미지 분석 및 데이터 저장 과정의 원자성을 보장했습니다.
* **공통 로직 정리**: `ItemMatchRepository`에 `findByIdOrThrow` 디폴트 메서드를 추가하여 예외 처리 코드를 간소화했습니다.

---

## 📡 Manual Match API Response Details
수동 매칭(`POST /api/matches/manual`)은 습득물의 상태에 따라 다음과 같이 분기된 응답을 반환합니다.

| MatchManualType | 설명 | 반환 데이터 포함 사항 |
| :--- | :--- | :--- |
| **LOCKER** | 습득물이 현재 보관함에 들어있는 경우 | `match_id`, `match_manual_type`, `locker_id` |
| **CHAT** | 습득물이 보관함 외 장소에 있는 경우 | `match_id`, `match_manual_type` (`locker_id`는 null) |

수동 매칭 시 반환되는 `MatchManualResponse`는 `MatchManualType` (Enum)을 통해 후속 절차를 정의합니다.

> **Note:** 이를 통해 프론트엔드에서 매칭 성공 후 바로 보관함 정보를 보여줄지, 채팅으로 유도할지 결정할 수 있습니다.

---

## 💡 Reason
* 자동 매칭 시스템에서 발견된 후보군을 사용자가 최종 확인하거나, 시스템이 찾지 못한 경우 관리자가 수동으로 개입할 수 있는 인터페이스가 필요했습니다.
* 매칭 성사 시 해당 아이템과 관련된 다른 불필요한 매칭 후보들을 자동 정리하여 데이터의 일관성을 유지하기 위함입니다.
* 프로젝트 규모 확장에 대비해 아이템(Item) 도메인과 매칭(Match) 도메인의 DTO 구조를 명확히 분리하여 유지보수성을 높였습니다.

---

## ✅ Testing
* `ItemMatchController`를 통한 매칭 확정/거절 시나리오 API 테스트 수행
* 이미 확정된 아이템에 대해 수동 매칭 시도 시 `BadRequestException` 발생 여부 검증
* `rejectOthersByLostItem` 쿼리를 통한 연쇄 상태 변경(REJECTED) 정상 작동 확인
* FCM 토큰 유무 및 전송 결과에 따른 `NOTIFIED` 상태 변경 로직 검증

---

### `POST /api/matches/{matchId}/confirm`
<img width="394" height="478" alt="1  confirm-1" src="https://github.com/user-attachments/assets/68e1d53a-549d-4f40-9b66-21259e2c4baf" />
<img width="630" height="339" alt="1  confirm-2" src="https://github.com/user-attachments/assets/9ffe42d0-64a7-4993-8551-3005c462d4db" />

---

### `POST /api/matches/{matchId}/reject`
<img width="397" height="483" alt="2  reject-1" src="https://github.com/user-attachments/assets/ca8159f6-74f2-4c4d-ac56-3c47f3bf88ff" />
<img width="692" height="118" alt="2  reject-2" src="https://github.com/user-attachments/assets/246087a9-179f-4819-80d6-a49124069761" />

---


### `POST /api/matches/manual`
<img width="400" height="502" alt="3  manual-1" src="https://github.com/user-attachments/assets/88fa8f2a-1c7e-44a1-ba63-a6dec4169fc0" />
<img width="635" height="90" alt="3  manual-2" src="https://github.com/user-attachments/assets/205f4afc-1f78-4153-addb-3bc01a8df746" />
<img width="389" height="298" alt="5  처리" src="https://github.com/user-attachments/assets/64f46f13-f544-46df-bb7a-eed9f40e282b" />
<img width="397" height="442" alt="5  처리2" src="https://github.com/user-attachments/assets/22cae040-19ad-49a1-873e-8099949d3bca" />

---


### `Log`
<img width="250" height="140" alt="4  logs" src="https://github.com/user-attachments/assets/9c624086-a0a0-423c-a3a1-42cb9ec03e08" />

---

### FCM
<img width="349" height="148" alt="6  FCM" src="https://github.com/user-attachments/assets/0855948b-b11b-43c0-a8af-f4770ae75f4f" />
<img width="701" height="94" alt="6  FCM2" src="https://github.com/user-attachments/assets/ee66ff6b-06da-45d3-9af8-e11abec1fd19" />
<img width="637" height="46" alt="6 FCM3" src="https://github.com/user-attachments/assets/21e72f83-202b-499c-b566-d8a2ddcb9e2f" />

---
