### PR TITLE
TimetableRepository — N+1 DELETE 제거  TimetableService.syncTimetable — N+1 SELECT 제거

### DIFF
--- a/src/main/java/com/zoopick/server/repository/CourseRepository.java
+++ b/src/main/java/com/zoopick/server/repository/CourseRepository.java
@@ -3,11 +3,13 @@ package com.zoopick.server.repository;
 import com.zoopick.server.entity.Course;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
+    @EntityGraph(attributePaths = {"room", "room.building"})
     @Query("SELECT c FROM Course c WHERE c.year = :year AND c.semester = :semester " +
            "AND (:keyword IS NULL OR c.courseName LIKE %:keyword%)")
     Page<Course> searchCourses(@Param("year") Integer year, 

--- a/src/main/java/com/zoopick/server/repository/TimetableRepository.java
+++ b/src/main/java/com/zoopick/server/repository/TimetableRepository.java
@@ -4,11 +4,17 @@ import com.zoopick.server.entity.Timetable;
 import com.zoopick.server.entity.TimetableGroup;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface TimetableRepository extends JpaRepository<Timetable, Long> {
     @EntityGraph(attributePaths = {"course", "course.room", "course.room.building"})
     List<Timetable> findAllByTimetableGroup(TimetableGroup timetableGroup);
-    void deleteAllByTimetableGroup(TimetableGroup timetableGroup);
+
+    @Modifying
+    @Query("DELETE FROM Timetable t WHERE t.timetableGroup = :group")
+    void deleteAllByTimetableGroup(@Param("group") TimetableGroup group);
 }

--- a/src/main/java/com/zoopick/server/repository/TimetableRepository.java
+++ b/src/main/java/com/zoopick/server/repository/TimetableRepository.java
@@ -2,11 +2,13 @@ package com.zoopick.server.repository;
 
 import com.zoopick.server.entity.Timetable;
 import com.zoopick.server.entity.TimetableGroup;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface TimetableRepository extends JpaRepository<Timetable, Long> {
+    @EntityGraph(attributePaths = {"course", "course.room", "course.room.building"})
     List<Timetable> findAllByTimetableGroup(TimetableGroup timetableGroup);
     void deleteAllByTimetableGroup(TimetableGroup timetableGroup);
 }

--- a/src/main/java/com/zoopick/server/service/TimetableService.java
+++ b/src/main/java/com/zoopick/server/service/TimetableService.java
@@ -12,7 +12,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -73,34 +75,25 @@ public class TimetableService {
         List<Course> courses = timetables.stream()
                 .map(Timetable::getCourse)
                 .toList();
-        List<CourseSchedule> courseSchedules = courseScheduleRepository.findAllByCourseIn(courses);
-        return timetableRepository.findAllByTimetableGroup(group).stream()
+        
+        Map<Long, List<CourseSchedule>> scheduleMap = courseScheduleRepository.findAllByCourseIn(courses).stream()
+                .collect(Collectors.groupingBy(s -> s.getCourse().getId()));
+
+        return timetables.stream()
                 .map(t -> {
                     Course c = t.getCourse();
                     Room r = c.getRoom();
                     Building b = r.getBuilding();
+                    List<CourseSchedule> schedules = scheduleMap.getOrDefault(c.getId(), Collections.emptyList());
                     return new TimetableCourseRecord(
                             c.getId(), c.getCourseName(),
                             r.getName(), b.getName(), b.getCode(), t.getColor(),
-                            collectCourseScheduleRecord(c, courseSchedules)
+                            schedules.stream()
+                                    .map(s -> new TimetableCourseScheduleRecord(s.getDayOfWeek(), s.getStartTime(), s.getEndTime()))
+                                    .toList()
                     );
                 })
                 .collect(Collectors.toList());
-    }
-
-    private List<TimetableCourseScheduleRecord> collectCourseScheduleRecord(Course course, List<CourseSchedule> allCourseSchedules) {
-        return allCourseSchedules.stream()
-                .filter(schedule -> schedule.getCourse().getId().equals(course.getId()))
-                .map(schedule -> new TimetableCourseScheduleRecord(
-                        schedule.getDayOfWeek(), schedule.getStartTime(), schedule.getEndTime()
-                ))
-                .toList();
-    }
-
-    private List<CourseSchedule> filterCourseSchedules(Course course, List<CourseSchedule> allCourseSchedules) {
-        return allCourseSchedules.stream()
-                .filter(schedule -> schedule.getCourse().getId().equals(course.getId()))
-                .toList();
     }
 
     @Transactional
@@ -114,17 +107,20 @@ public class TimetableService {
         timetableRepository.flush();
 
         // 2. 새로운 강의 데이터 로드 및 중복 검증
-        List<Timetable> newTimetables = new ArrayList<>();
         List<Long> courseIds = request.courses().stream()
                 .map(TimetableSyncRequest.CourseColorRequest::courseId)
                 .toList();
-        List<CourseSchedule> schedules = courseScheduleRepository.findAllByCourseIdIn(courseIds);
+        
+        Map<Long, List<CourseSchedule>> scheduleMap = courseScheduleRepository.findAllByCourseIdIn(courseIds).stream()
+                .collect(Collectors.groupingBy(s -> s.getCourse().getId()));
+
+        List<Timetable> newTimetables = new ArrayList<>();
         for (var req : request.courses()) {
             Course course = courseRepository.findById(req.courseId())
                     .orElseThrow(() -> DataNotFoundException.from("강의", req.courseId()));
 
             // 시간 중복 체크
-            validateOverlap(newTimetables, course, schedules);
+            validateOverlap(newTimetables, course, scheduleMap);
 
             newTimetables.add(Timetable.builder()
                     .course(course)
@@ -148,25 +144,31 @@ public class TimetableService {
 
     public Page<TimetableCourseRecord> searchCourses(Integer year, Integer semester, String keyword, Pageable pageable) {
         Page<Course> courses = courseRepository.searchCourses(year, semester, keyword, pageable);
-        List<CourseSchedule> schedules = courseScheduleRepository.findAllByCourseIn(courses.getContent());
+        
+        Map<Long, List<CourseSchedule>> scheduleMap = courseScheduleRepository.findAllByCourseIn(courses.getContent()).stream()
+                .collect(Collectors.groupingBy(s -> s.getCourse().getId()));
 
-        return courseRepository.searchCourses(year, semester, keyword, pageable)
-                .map(c -> {
-                    Room r = c.getRoom();
-                    Building b = r.getBuilding();
-                    return new TimetableCourseRecord(
-                            c.getId(), c.getCourseName(),
-                            r.getName(), b.getName(), b.getCode(), null,
-                            collectCourseScheduleRecord(c, schedules)
-                    );
-                });
+        return courses.map(c -> {
+            Room r = c.getRoom();
+            Building b = r.getBuilding();
+            List<CourseSchedule> schedules = scheduleMap.getOrDefault(c.getId(), Collections.emptyList());
+            return new TimetableCourseRecord(
+                    c.getId(), c.getCourseName(),
+                    r.getName(), b.getName(), b.getCode(), null,
+                    schedules.stream()
+                            .map(s -> new TimetableCourseScheduleRecord(s.getDayOfWeek(), s.getStartTime(), s.getEndTime()))
+                            .toList()
+            );
+        });
     }
 
-    public void validateOverlap(List<Timetable> existing, Course target, List<CourseSchedule> allCourseSchedules) {
+    private void validateOverlap(List<Timetable> existing, Course target, Map<Long, List<CourseSchedule>> scheduleMap) {
+        List<CourseSchedule> targetSchedules = scheduleMap.getOrDefault(target.getId(), Collections.emptyList());
+        
         for (Timetable t : existing) {
             Course c = t.getCourse();
-            List<CourseSchedule> comparingSchedules = filterCourseSchedules(c, allCourseSchedules);
-            List<CourseSchedule> targetSchedules = filterCourseSchedules(target, allCourseSchedules);
+            List<CourseSchedule> comparingSchedules = scheduleMap.getOrDefault(c.getId(), Collections.emptyList());
+            
             if (hasOverlap(comparingSchedules, targetSchedules)) {
                 String message = String.format("강의 시간이 겹칩니다: %s & %s", c.getCourseName(), target.getCourseName());
                 throw new BadRequestException(message, message);

--- a/src/main/java/com/zoopick/server/service/TimetableService.java
+++ b/src/main/java/com/zoopick/server/service/TimetableService.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -114,9 +115,12 @@ public class TimetableService {
         Map<Long, List<CourseSchedule>> scheduleMap = courseScheduleRepository.findAllByCourseIdIn(courseIds).stream()
                 .collect(Collectors.groupingBy(s -> s.getCourse().getId()));
 
+        Map<Long, Course> courseMap = courseRepository.findAllById(courseIds).stream()
+                .collect(Collectors.toMap(Course::getId, c -> c));
+
         List<Timetable> newTimetables = new ArrayList<>();
         for (var req : request.courses()) {
-            Course course = courseRepository.findById(req.courseId())
+            Course course = Optional.ofNullable(courseMap.get(req.courseId()))
                     .orElseThrow(() -> DataNotFoundException.from("강의", req.courseId()));
 
             // 시간 중복 체크


### PR DESCRIPTION

  TimetableRepository — N+1 DELETE 제거
  - 기존 derived delete(void deleteAllByTimetableGroup)는 SELECT 후 엔티티별 DELETE 수행 가능 
  - @Modifying + @Query("DELETE FROM Timetable t WHERE t.timetableGroup = :group")으로 단일 벌크 DELETE 쿼리로 변경

  TimetableService.syncTimetable — N+1 SELECT 제거
  - 기존: 루프에서 courseRepository.findById() N번 호출 → 강의 수만큼 쿼리
  - 변경: findAllById(courseIds)로 1번에 전부 가져온 후 Map<Long, Course>로 O(1) 접근
  - Optional.ofNullable(courseMap.get(...)) 패턴으로 존재하지 않는 강의 id에 대한 예외 처리도 유지
