### PR TITLE
Feat/change item match logic

### DIFF
--- a/src/main/java/com/zoopick/server/dto/match/CreateMatchEvent.java
+++ b/src/main/java/com/zoopick/server/dto/match/CreateMatchEvent.java
@@ -1,5 +1,3 @@
 package com.zoopick.server.dto.match;
 
-import com.zoopick.server.entity.Item;
-
-public record CreateMatchEvent(Long matchId, Item lostItem, Item foundItem) {}
+public record CreateMatchEvent(Long matchId, Long lostItemId, Long foundItemId) {}

--- a/src/main/java/com/zoopick/server/dto/match/CreateMatchEvent.java
+++ b/src/main/java/com/zoopick/server/dto/match/CreateMatchEvent.java
@@ -1,0 +1,5 @@
+package com.zoopick.server.dto.match;
+
+import com.zoopick.server.entity.Item;
+
+public record CreateMatchEvent(Long matchId, Item lostItem, Item foundItem) {}

--- a/src/main/java/com/zoopick/server/dto/match/CreateMatchEventListner.java
+++ b/src/main/java/com/zoopick/server/dto/match/CreateMatchEventListner.java
@@ -1,0 +1,45 @@
+package com.zoopick.server.dto.match;
+
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.zoopick.server.entity.Item;
+import com.zoopick.server.entity.ItemMatch;
+import com.zoopick.server.entity.MatchStatus;
+import com.zoopick.server.repository.ItemMatchRepository;
+import com.zoopick.server.repository.ItemPostRepository;
+import com.zoopick.server.service.notification.NotificationService;
+import com.zoopick.server.service.notification.SendNotificationCommand;
+import com.zoopick.server.service.notification.payload.MatchFoundPayload;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CreateMatchEventListner {
+    private final NotificationService notificationService;
+    private final ItemMatchRepository itemMatchRepository;
+    private final ItemPostRepository itemPostRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleMatchCreated(CreateMatchEvent event) {
+        ItemMatch match = itemMatchRepository.findByIdOrThrow(event.matchId());
+        Item lostItem = event.lostItem();
+        Item foundItem = event.foundItem();
+        String title = itemPostRepository.findByItem(lostItem).getTitle();
+        String location = foundItem.getLocationName();
+        try {
+            notificationService.send(lostItem.getReporter(), new SendNotificationCommand(
+                    "분실물 발견",
+                    "회원님이 등록한 %s와 유사한 물건이 %s에서 발견됐어요.".formatted(title, location),
+                    MatchFoundPayload.of(lostItem, match)));
+            match.setStatus(MatchStatus.NOTIFIED);
+            itemMatchRepository.save(match);
+            log.error("FCM 전송 성공 matchId: {}", match.getId());
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM 전송 실패 (matchId: {}): {}", match.getId(), e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
@@ -18,73 +18,73 @@ import java.util.List;
 @Repository
 public interface ItemMatchRepository extends JpaRepository<ItemMatch, Long> {
 
+
     default ItemMatch findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(() -> DataNotFoundException.from("매칭", id));
     }
 
     @Query(value = """
-            SELECT *
-            FROM (
-                SELECT
-                    i.id AS itemId,
-                    1 - (i.embedding <=> CAST(:embedding AS vector)) AS score
-                FROM zoopick.items i
-                WHERE i.category = CAST(:category AS item_category)
-                  AND i.color = CAST(:color AS item_color)
-                  AND i.type <> CAST(:excludeType AS item_type)
-                  AND i.reporter_id <> :reporterId
-                  AND i.returned_at IS NULL
-                ORDER BY i.embedding <=> CAST(:embedding AS vector)
-                LIMIT 100
-            ) t
-            WHERE t.score >= :threshold
-            """, nativeQuery = true)
+    SELECT *
+    FROM (
+        SELECT
+            i.id AS itemId,
+            1 - (i.embedding <=> CAST(:embedding AS vector)) AS score
+        FROM zoopick.items i
+        WHERE i.type <> CAST(:excludeType AS item_type)
+          AND i.reporter_id <> :reporterId
+          AND i.returned_at IS NULL
+          AND i.category = CAST(:category AS item_category)
+        ORDER BY i.embedding <=> CAST(:embedding AS vector)
+        LIMIT 100
+    ) t
+    WHERE t.score >= :threshold
+        LIMIT 30
+    """, nativeQuery = true)
     List<SimilarItemProjection> findSimilarItems(@Param("embedding") Vector embedding,
-            @Param("excludeType") String excludeType,
-            @Param("category") String category,
-            @Param("color") String color,
-            @Param("reporterId") Long reporterId,
-            @Param("threshold") float threshold);
+                                                 @Param("excludeType") String excludeType,
+                                                 @Param("category") String category,
+                                                 @Param("reporterId") Long reporterId,
+                                                 @Param("threshold") float threshold);
 
     // 중복 체크
     boolean existsByLostItemAndFoundItem(Item lostItem, Item foundItem);
 
     @Query(value = """
-            SELECT
-            m.id as matchId,                 -- 매칭 ID
-            f.id as foundItemId,             -- 매칭된 item ID
-            p.id as foundPostId,             -- 매칭된 post ID
-            p.title as foundPostTitle,       -- 매칭된 post 제목
-            f.location_name  as locationName,-- 매칭된 post 장소
-            f.image_url as foundImageUrl,    -- 매칭된 item 이미지 url
-            u.nickname as foundNickname,     -- 찾은 사람 닉네임
-            u.department as foundDepartment, -- 찾은 사람 과
-            m.score as score,                -- 매칭 점수
-            m.status as status               -- 현재 상태
-            FROM items i
-            JOIN item_matches m ON i.id = m.lost_item_id
-            JOIN items f ON m.found_item_id = f.id
-            JOIN item_posts p on f.id = p.item_id
-            JOIN users u ON u.id = f.reporter_id
-            WHERE i.type = 'LOST' -- 내가 잃어버린 것만
-            AND m.status IN ('CANDIDATE', 'NOTIFIED') -- 아직 매칭되지 않은 것들
-            AND i.reporter_id=:userId -- 내거만
-            AND f.reporter_id<>:userId -- found한 아이템이 내거면 안됨
-            ORDER BY m.score desc -- 내림차순으로 뽑음
-            """, nativeQuery = true)
+    SELECT 
+    m.id as matchId,                 -- 매칭 ID
+    f.id as foundItemId,             -- 매칭된 item ID
+    p.id as foundPostId,             -- 매칭된 post ID
+    p.title as foundPostTitle,       -- 매칭된 post 제목
+    f.location_name  as locationName,-- 매칭된 post 장소
+    f.image_url as foundImageUrl,    -- 매칭된 item 이미지 url
+    u.nickname as foundNickname,     -- 찾은 사람 닉네임
+    u.department as foundDepartment, -- 찾은 사람 과
+    m.score as score,                -- 매칭 점수
+    m.status as status               -- 현재 상태
+    FROM items i
+    JOIN item_matches m ON i.id = m.lost_item_id
+    JOIN items f ON m.found_item_id = f.id
+    JOIN item_posts p on f.id = p.item_id
+    JOIN users u ON u.id = f.reporter_id
+    WHERE i.type = 'LOST' -- 내가 잃어버린 것만
+    AND m.status IN ('CANDIDATE', 'NOTIFIED') -- 아직 매칭되지 않은 것들
+    AND i.reporter_id=:userId -- 내거만
+    AND f.reporter_id<>:userId -- found한 아이템이 내거면 안됨
+    ORDER BY m.score desc -- 내림차순으로 뽑음
+    """, nativeQuery = true)
     List<ItemMatchProjection> itemMatchesByLostItem(@Param("userId") Long userId);
 
     // 매칭 컨펌된 것 제외 모든 물품을 다 rejected
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = """
-                UPDATE item_matches SET status = 'REJECTED', updated_at = now()
-                WHERE (lost_item_id = :lostItemId OR found_item_id = :foundItemId)
-                AND id != :matchId
-                AND status IN ('CANDIDATE', 'NOTIFIED')
-            """, nativeQuery = true)
+    UPDATE item_matches SET status = 'REJECTED'
+    WHERE (lost_item_id = :lostItemId OR found_item_id = :foundItemId)
+    AND id != :matchId
+    AND status IN ('CANDIDATE', 'NOTIFIED')
+""", nativeQuery = true)
     int rejectOthersByLostItem(@Param("matchId") Long matchId,
-            @Param("lostItemId") Long lostItemId,
-            @Param("foundItemId") Long foundItemId);
+                                @Param("lostItemId") Long lostItemId,
+                                @Param("foundItemId") Long foundItemId);
 
     // CONFIRMED된 매칭이 있는지 확인
     boolean existsByLostItemAndStatus(Item lostItem, MatchStatus status);

--- a/src/main/java/com/zoopick/server/service/CreateMatchEventListner.java
+++ b/src/main/java/com/zoopick/server/service/CreateMatchEventListner.java
@@ -1,17 +1,20 @@
-package com.zoopick.server.dto.match;
+package com.zoopick.server.service;
 
 import com.google.firebase.messaging.FirebaseMessagingException;
+import com.zoopick.server.dto.match.CreateMatchEvent;
 import com.zoopick.server.entity.Item;
 import com.zoopick.server.entity.ItemMatch;
 import com.zoopick.server.entity.MatchStatus;
 import com.zoopick.server.repository.ItemMatchRepository;
 import com.zoopick.server.repository.ItemPostRepository;
+import com.zoopick.server.repository.ItemRepository;
 import com.zoopick.server.service.notification.NotificationService;
 import com.zoopick.server.service.notification.SendNotificationCommand;
 import com.zoopick.server.service.notification.payload.MatchFoundPayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -22,12 +25,14 @@ public class CreateMatchEventListner {
     private final NotificationService notificationService;
     private final ItemMatchRepository itemMatchRepository;
     private final ItemPostRepository itemPostRepository;
+    private final ItemRepository itemRepository;
 
+    @Transactional
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMatchCreated(CreateMatchEvent event) {
         ItemMatch match = itemMatchRepository.findByIdOrThrow(event.matchId());
-        Item lostItem = event.lostItem();
-        Item foundItem = event.foundItem();
+        Item lostItem = itemRepository.findByIdOrThrow(event.lostItemId());
+        Item foundItem = itemRepository.findByIdOrThrow(event.foundItemId());
         String title = itemPostRepository.findByItem(lostItem).getTitle();
         String location = foundItem.getLocationName();
         try {
@@ -36,8 +41,7 @@ public class CreateMatchEventListner {
                     "회원님이 등록한 %s와 유사한 물건이 %s에서 발견됐어요.".formatted(title, location),
                     MatchFoundPayload.of(lostItem, match)));
             match.setStatus(MatchStatus.NOTIFIED);
-            itemMatchRepository.save(match);
-            log.error("FCM 전송 성공 matchId: {}", match.getId());
+            log.info("FCM 전송 성공 matchId: {}", match.getId());
         } catch (FirebaseMessagingException e) {
             log.error("FCM 전송 실패 (matchId: {}): {}", match.getId(), e.getMessage());
         }

--- a/src/main/java/com/zoopick/server/service/CreateMatchEventListner.java
+++ b/src/main/java/com/zoopick/server/service/CreateMatchEventListner.java
@@ -14,6 +14,7 @@ import com.zoopick.server.service.notification.payload.MatchFoundPayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -27,7 +28,7 @@ public class CreateMatchEventListner {
     private final ItemPostRepository itemPostRepository;
     private final ItemRepository itemRepository;
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMatchCreated(CreateMatchEvent event) {
         ItemMatch match = itemMatchRepository.findByIdOrThrow(event.matchId());

--- a/src/main/java/com/zoopick/server/service/ItemMatchService.java
+++ b/src/main/java/com/zoopick/server/service/ItemMatchService.java
@@ -1,17 +1,11 @@
 package com.zoopick.server.service;
 
-import com.google.firebase.messaging.FirebaseMessagingException;
 import com.zoopick.server.dto.match.*;
 import com.zoopick.server.entity.*;
 import com.zoopick.server.exception.BadRequestException;
-import com.zoopick.server.exception.DataNotFoundException;
 import com.zoopick.server.repository.ItemMatchRepository;
-import com.zoopick.server.repository.ItemPostRepository;
 import com.zoopick.server.repository.ItemRepository;
 import com.zoopick.server.repository.LockerRepository;
-import com.zoopick.server.service.notification.NotificationService;
-import com.zoopick.server.service.notification.SendNotificationCommand;
-import com.zoopick.server.service.notification.payload.MatchFoundPayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -32,8 +26,6 @@ public class ItemMatchService {
     private final ItemRepository itemRepository;
     private final ItemMatchRepository itemMatchRepository;
     private final LockerRepository lockerRepository;
-    private final NotificationService notificationService;
-    private final ItemPostRepository itemPostRepository;
     private final ApplicationEventPublisher eventPublisher;
     @Value("${zoopick.similarity.threshold}")
     private float similarityThreshold;
@@ -59,7 +51,7 @@ public class ItemMatchService {
         }
 
         Map<Long, Item> itemMap = itemRepository.findAllById(
-                        similarItems.stream().map(SimilarItemResult::getItemId).toList())
+                similarItems.stream().map(SimilarItemResult::getItemId).toList())
                 .stream()
                 .collect(Collectors.toMap(Item::getId, i -> i));
 
@@ -89,10 +81,7 @@ public class ItemMatchService {
                         .status(MatchStatus.CANDIDATE)
                         .build());
                 log.info("매칭된 아이템 ID: {}", foundItemInDb.getId());
-                eventPublisher.publishEvent(new CreateMatchEvent(savedMatch.getId(), lostItem, foundItem));
-                if (sendMatchNotification(lostItem, foundItem, savedMatch)) {
-                    savedMatch.setStatus(MatchStatus.NOTIFIED);
-                }
+                eventPublisher.publishEvent(new CreateMatchEvent(savedMatch.getId(), lostItem.getId(), foundItem.getId()));
             }
         }
         log.info("매칭 종료 ID: {}", targetItem.getId());
@@ -173,25 +162,6 @@ public class ItemMatchService {
                     .matchId(savedMatch.getId())
                     .matchManualType(MatchManualType.CHAT)
                     .build();
-        }
-    }
-
-    private boolean sendMatchNotification(Item lostItem, Item foundItem, ItemMatch match) {
-        String title = itemPostRepository.findByItem(lostItem).getTitle();
-        String location = foundItem.getLocationName();
-        try {
-            notificationService.send(lostItem.getReporter(), new SendNotificationCommand(
-                    "분실물 발견",
-                    "회원님이 등록한 %s와 유사한 물건이 %s에서 발견됐어요.".formatted(title, location),
-                    MatchFoundPayload.of(lostItem, match)));
-            return true;
-        } catch (FirebaseMessagingException e) {
-            log.error("FCM 전송 실패 (matchId: {}): {}", match.getId(), e.getMessage());
-            return false;
-        } catch (DataNotFoundException e) {
-            // FCM 토큰 없는 유저
-            log.warn("FCM 토큰 없음 (matchId: {}, userId: {})", match.getId(), lostItem.getReporter().getId());
-            return false;
         }
     }
 

--- a/src/main/java/com/zoopick/server/service/ItemMatchService.java
+++ b/src/main/java/com/zoopick/server/service/ItemMatchService.java
@@ -12,9 +12,9 @@ import com.zoopick.server.repository.ItemMatchRepository;
 import com.zoopick.server.repository.ItemPostRepository;
 import com.zoopick.server.repository.ItemRepository;
 import com.zoopick.server.repository.LockerRepository;
-import com.zoopick.server.service.notification.payload.MatchFoundPayload;
-import com.zoopick.server.service.notification.SendNotificationCommand;
 import com.zoopick.server.service.notification.NotificationService;
+import com.zoopick.server.service.notification.SendNotificationCommand;
+import com.zoopick.server.service.notification.payload.MatchFoundPayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,7 +22,10 @@ import org.springframework.data.domain.Vector;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -42,12 +45,11 @@ public class ItemMatchService {
         Item targetItem = itemRepository.findByIdOrThrow(itemId); // 게시글이 올라간 아이템
         Vector embedding = Vector.of(targetItem.getEmbedding());
         List<SimilarItemResult> similarItems = itemMatchRepository.findSimilarItems(
-                        embedding,
-                        targetItem.getType().name(),
-                        targetItem.getCategory().name(),
-                        targetItem.getColor().name(),
-                        targetItem.getReporter().getId(),
-                        similarityThreshold)
+                embedding,
+                targetItem.getType().name(),
+                targetItem.getCategory().name(),
+                targetItem.getReporter().getId(),
+                similarityThreshold)
                 .stream()
                 .map(p -> new SimilarItemResult(p.getItemId(), p.getScore()))
                 .toList();
@@ -56,24 +58,39 @@ public class ItemMatchService {
             log.warn("매칭된 아이템이 없습니다.");
             return;
         }
-        for (SimilarItemResult similarItemResult : similarItems) {
-            Item foundItemInDb = itemRepository.findByIdOrThrow(similarItemResult.getItemId());
-            log.info("매칭된 아이템 ID: {}", foundItemInDb.getId());
+
+        Map<Long, Item> itemMap = itemRepository.findAllById(
+                        similarItems.stream().map(SimilarItemResult::getItemId).toList())
+                .stream()
+                .collect(Collectors.toMap(Item::getId, i -> i));
+
+        List<SimilarItemResult> top5 = similarItems.stream()
+                .map(s -> {
+                    Item found = itemMap.get(s.getItemId());
+                    float score = (float) s.getScore();
+                    if (targetItem.getColor() == found.getColor()) score *= 1.02f;
+                    return new SimilarItemResult(s.getItemId(), score);
+                })
+                .sorted(Comparator.comparingDouble(SimilarItemResult::getScore).reversed())
+                .limit(5)
+                .toList();
+
+        for (SimilarItemResult s : top5) {
+            Item foundItemInDb = itemMap.get(s.getItemId());
             // 게시글에 올라온 아이템이 LOST라면 lostItem에, FOUND라면 foundItem에
             Item lostItem = targetItem.getType() == ItemType.LOST ? targetItem : foundItemInDb;
             Item foundItem = targetItem.getType() == ItemType.LOST ? foundItemInDb : targetItem;
+
             // 중복 저장 방지
             if (!itemMatchRepository.existsByLostItemAndFoundItem(lostItem, foundItem)) {
-                ItemMatch itemMatch = ItemMatch
-                        .builder()
-                        .score((float) similarItemResult.getScore())
+                ItemMatch savedMatch = itemMatchRepository.save(ItemMatch.builder()
+                        .score((float) s.getScore())
                         .lostItem(lostItem)
                         .foundItem(foundItem)
                         .status(MatchStatus.CANDIDATE)
-                        .build();
-                ItemMatch savedMatch = itemMatchRepository.save(itemMatch);
-                boolean isSent = sendMatchNotification(lostItem, foundItem, savedMatch);
-                if (isSent) {
+                        .build());
+                log.info("매칭된 아이템 ID: {}", foundItemInDb.getId());
+                if (sendMatchNotification(lostItem, foundItem, savedMatch)) {
                     savedMatch.setStatus(MatchStatus.NOTIFIED);
                 }
             }
@@ -94,8 +111,7 @@ public class ItemMatchService {
                         p.getFoundNickname(),
                         p.getFoundDepartment(),
                         p.getScore(),
-                        MatchStatus.valueOf(p.getStatus())
-                ))
+                        MatchStatus.valueOf(p.getStatus())))
                 .toList();
     }
 
@@ -138,7 +154,7 @@ public class ItemMatchService {
         itemMatchRepository.rejectOthersByLostItem(savedMatch.getId(), lostItem.getId(), foundItem.getId());
         log.info("매칭 저장 완료 ID: {}", savedMatch.getId());
 
-        //LOCKER, CHAT 분기
+        // LOCKER, CHAT 분기
         if (foundItem.getStatus().equals(ItemStatus.IN_LOCKER)) {
             Locker locker = lockerRepository.findLockerByCurrentItem(foundItem);
             log.info("매칭 LOCKER {} <-> {}", request.getLostItemId(), request.getFoundItemId());
@@ -163,8 +179,7 @@ public class ItemMatchService {
             notificationService.send(lostItem.getReporter(), new SendNotificationCommand(
                     "분실물 발견",
                     "회원님이 등록한 %s와 유사한 물건이 %s에서 발견됐어요.".formatted(title, location),
-                    MatchFoundPayload.of(lostItem, match)
-            ));
+                    MatchFoundPayload.of(lostItem, match)));
             return true;
         } catch (FirebaseMessagingException e) {
             log.error("FCM 전송 실패 (matchId: {}): {}", match.getId(), e.getMessage());

--- a/src/main/java/com/zoopick/server/service/ItemMatchService.java
+++ b/src/main/java/com/zoopick/server/service/ItemMatchService.java
@@ -1,10 +1,7 @@
 package com.zoopick.server.service;
 
 import com.google.firebase.messaging.FirebaseMessagingException;
-import com.zoopick.server.dto.match.ItemMatchResultResponse;
-import com.zoopick.server.dto.match.MatchManualRequest;
-import com.zoopick.server.dto.match.MatchManualResponse;
-import com.zoopick.server.dto.match.SimilarItemResult;
+import com.zoopick.server.dto.match.*;
 import com.zoopick.server.entity.*;
 import com.zoopick.server.exception.BadRequestException;
 import com.zoopick.server.exception.DataNotFoundException;
@@ -18,6 +15,7 @@ import com.zoopick.server.service.notification.payload.MatchFoundPayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Vector;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +26,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 @Slf4j
 public class ItemMatchService {
@@ -37,9 +34,11 @@ public class ItemMatchService {
     private final LockerRepository lockerRepository;
     private final NotificationService notificationService;
     private final ItemPostRepository itemPostRepository;
+    private final ApplicationEventPublisher eventPublisher;
     @Value("${zoopick.similarity.threshold}")
     private float similarityThreshold;
 
+    @Transactional
     public void createMatch(Long itemId) {
         log.info("매칭 시작 ID: {}", itemId);
         Item targetItem = itemRepository.findByIdOrThrow(itemId); // 게시글이 올라간 아이템
@@ -69,7 +68,7 @@ public class ItemMatchService {
                     Item found = itemMap.get(s.getItemId());
                     float score = (float) s.getScore();
                     if (targetItem.getColor() == found.getColor()) score *= 1.02f;
-                    return new SimilarItemResult(s.getItemId(), score);
+                    return new SimilarItemResult(s.getItemId(), Math.min(score, 1.0f));
                 })
                 .sorted(Comparator.comparingDouble(SimilarItemResult::getScore).reversed())
                 .limit(5)
@@ -90,6 +89,7 @@ public class ItemMatchService {
                         .status(MatchStatus.CANDIDATE)
                         .build());
                 log.info("매칭된 아이템 ID: {}", foundItemInDb.getId());
+                eventPublisher.publishEvent(new CreateMatchEvent(savedMatch.getId(), lostItem, foundItem));
                 if (sendMatchNotification(lostItem, foundItem, savedMatch)) {
                     savedMatch.setStatus(MatchStatus.NOTIFIED);
                 }
@@ -98,6 +98,7 @@ public class ItemMatchService {
         log.info("매칭 종료 ID: {}", targetItem.getId());
     }
 
+    @Transactional
     public List<ItemMatchResultResponse> getItemMatchResult(Long userId) {
         return itemMatchRepository.itemMatchesByLostItem(userId)
                 .stream()
@@ -115,6 +116,7 @@ public class ItemMatchService {
                 .toList();
     }
 
+    @Transactional
     public void confirmMatch(Long matchId) {
         ItemMatch itemMatch = itemMatchRepository.findByIdOrThrow(matchId);
         Item lostItem = itemMatch.getLostItem();
@@ -129,12 +131,14 @@ public class ItemMatchService {
         log.info("매칭 CONFIRMED ID: {}", matchId);
     }
 
+    @Transactional
     public void rejectMatch(Long matchId) {
         ItemMatch itemMatch = itemMatchRepository.findByIdOrThrow(matchId);
         itemMatch.setStatus(MatchStatus.REJECTED);
         log.info("매칭 REJECTED ID: {}", matchId);
     }
 
+    @Transactional
     public MatchManualResponse matchManual(MatchManualRequest request) {
         log.info("수동 매칭 시작: {} <-> {}", request.getLostItemId(), request.getFoundItemId());
         Item lostItem = itemRepository.findByIdOrThrow(request.getLostItemId());


### PR DESCRIPTION
## 📌 핵심 요약
매칭 로직의 결합도를 낮추기 위해 알림 발송 프로세스를 비동기 이벤트로 분리하고, DB 쿼리 최적화 및 색상 가중치 알고리즘을 도입하여 매칭 정확도를 개선했습니다.

## 📝 상세 변경 사항

### 1. 이벤트 기반 아키텍처 도입 (Event-Driven)
* **`CreateMatchEvent` 신설**: 매칭 ID, 분실물 ID, 습득물 ID를 포함하는 레코드형 이벤트 객체를 추가했습니다.
* **`CreateMatchEventListner` 구현**: 
    * 기존 `ItemMatchService`에 섞여 있던 FCM 알림 발송 로직을 별도 리스너로 이관했습니다.
    * `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)`를 사용하여, 매칭 정보가 DB에 최종 커밋된 직후에만 알림이 발송되도록 안정성을 확보했습니다.
    * 알림 전송 성공 시 매칭 상태를 `NOTIFIED`로 업데이트하는 책임을 분리했습니다.

### 2. 매칭 알고리즘 및 검색 로직 최적화
* **Repository 쿼리 튜닝**: 
    * `findSimilarItems` 네이티브 쿼리에서 하드코딩된 필터링 조건을 정비하고, 최종 결과 세트를 30개로 제한(`LIMIT 30`)하여 조회 성능을 높였습니다.
    * 쿼리 파라미터에서 `color`를 제외하고, 대신 서비스 레이어에서 정밀 스코어링을 수행하도록 변경했습니다.
* **색상 가중치(Color Weight) 도입**:
    * 단순 벡터 유사도에 더해, 분실물과 습득물의 색상이 일치할 경우 점수에 `1.02f` 가중치를 부여합니다.
    * 최종 점수가 1.0을 초과하지 않도록 `Math.min(score, 1.0f)` 처리를 추가했습니다.
* **상위 결과 제한**: 유사도가 높은 후보군 중 최상위 5개(`limit(5)`)만 실제 매칭 데이터로 생성하도록 로직을 강화했습니다.

### 3. 리팩토링 및 성능 개선
* **Batch Select 적용**: 루프를 돌며 `findById`를 개별 호출하던 방식에서, `findAllById`를 통해 한 번에 조회 후 `Map`으로 캐싱하여 사용하는 방식으로 변경(N+1 문제 방지)했습니다.
* **의존성 정리**: `ItemMatchService`에서 불필요해진 `NotificationService`, `ItemPostRepository` 의존성을 제거하고 `ApplicationEventPublisher`를 주입받도록 수정했습니다.
* **트랜잭션 명시**: 클래스 레벨의 `@Transactional`을 제거하고, 실제 데이터 변경이 일어나는 개별 메서드 단위로 `@Transactional`을 명시하여 전파 범위를 명확히 했습니다.

## ❓ 변경 이유
* **시스템 유연성**: 알림 서버(FCM)의 응답 지연이나 장애가 핵심 비즈니스 로직인 '매칭 생성'에 영향을 주지 않도록 격리하기 위함입니다.
* **정확도 향상**: AI 임베딩 유사도만으로는 잡아내기 어려운 '색상 일치'라는 명확한 물리적 특성을 스코어링에 반영하여 매칭 품질을 높였습니다.
* **리소스 효율**: 불필요하게 많은 매칭 후보를 DB에 저장하지 않고 검증된 상위 항목만 관리하여 저장 공간과 처리 속도를 최적화했습니다.
---
**Related Issues:** Resolves: #63