### PR TITLE
Locker api 수정 

### DIFF
--- a/src/main/java/com/zoopick/server/config/SecurityConfig.java
+++ b/src/main/java/com/zoopick/server/config/SecurityConfig.java
@@ -40,6 +40,10 @@ public class SecurityConfig {
                 // Vision 및 CCTV API 허용 (테스트용)
                 .requestMatchers("/api/vision/**", "/api/cctv/**", "/api/internal/**").permitAll()
 
+                // IoT 디바이스(아두이노) 전용 엔드포인트 허용
+                .requestMatchers(HttpMethod.GET, "/api/lockers/*/pending").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/lockers/*/commands/*/ack").permitAll()
+
                 .requestMatchers("/api/metadata/**").permitAll()
                 
                 // [수정 포인트] 실제 테스트 주소인 /api/auth/... 계열을 모두 허용 목록에 추가

--- a/src/main/java/com/zoopick/server/controller/ItemPostController.java
+++ b/src/main/java/com/zoopick/server/controller/ItemPostController.java
@@ -77,4 +77,19 @@ public class ItemPostController {
         ItemPostRecord result = itemPostService.getItemPost(id);
         return ResponseEntity.ok(CommonResponse.success(result));
     }
+
+    @Operation(summary = "물품 소유자 정보 조회", description = "QR 스캔 시 해당 물품의 소유자(신고자) 정보를 조회합니다. 권한 확인이 필요합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "물품을 찾을 수 없음")
+    })
+    @GetMapping("/{itemId}/owner-info")
+    public ResponseEntity<CommonResponse<ItemOwnerInfoResult>> getOwnerInfo(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long itemId
+    ) {
+        ItemOwnerInfoResult result = itemPostService.getOwnerInfo(principal.id(), itemId);
+        return ResponseEntity.ok(CommonResponse.success(result));
+    }
 }

--- a/src/main/java/com/zoopick/server/controller/LockerController.java
+++ b/src/main/java/com/zoopick/server/controller/LockerController.java
@@ -44,7 +44,7 @@ public class LockerController {
             @RequestBody(required = false) UnlockRequest req) {
 
         Long itemId = (req != null) ? req.itemId() : null;
-        LockerCommand cmd = lockerService.requestUnlock(principal.email(), lockerId, itemId);
+        LockerCommand cmd = lockerService.requestUnlock(principal.id(), lockerId, itemId);
 
         return ResponseEntity.ok(Map.of(
                 "success", true,
@@ -66,7 +66,7 @@ public class LockerController {
     public ResponseEntity<Map<String, Object>> lock(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long lockerId) {
-        LockerCommand cmd = lockerService.requestLock(principal.email(), lockerId);
+        LockerCommand cmd = lockerService.requestLock(principal.id(), lockerId);
         return ResponseEntity.ok(Map.of(
                 "success", true,
                 "command_id", cmd.getId(),

--- a/src/main/java/com/zoopick/server/dto/item/ItemOwnerInfoResult.java
+++ b/src/main/java/com/zoopick/server/dto/item/ItemOwnerInfoResult.java
@@ -1,0 +1,7 @@
+package com.zoopick.server.dto.item;
+
+public record ItemOwnerInfoResult(
+    String nickname,
+    String department
+) {
+}

--- a/src/main/java/com/zoopick/server/entity/Locker.java
+++ b/src/main/java/com/zoopick/server/entity/Locker.java
@@ -23,5 +23,5 @@ public class Locker {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "current_item_id")
-    private Item currentItem;   // 보관 중인 아이템 (없으면 null)
+    private Item currentItem;   // 보관 중인 아이템 없으면 null
 }

--- a/src/main/java/com/zoopick/server/exception/ForbiddenException.java
+++ b/src/main/java/com/zoopick/server/exception/ForbiddenException.java
@@ -1,0 +1,15 @@
+package com.zoopick.server.exception;
+
+import org.jspecify.annotations.NullMarked;
+import org.springframework.http.HttpStatus;
+
+@NullMarked
+public class ForbiddenException extends ZoopickException {
+    public ForbiddenException(String clientMessage, String exceptionMessage) {
+        super(HttpStatus.FORBIDDEN, clientMessage, exceptionMessage);
+    }
+
+    public ForbiddenException(String message) {
+        super(HttpStatus.FORBIDDEN, message);
+    }
+}

--- a/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
@@ -90,4 +90,8 @@ public interface ItemMatchRepository extends JpaRepository<ItemMatch, Long> {
     boolean existsByLostItemAndStatus(Item lostItem, MatchStatus status);
 
     boolean existsByFoundItemAndStatus(Item foundItem, MatchStatus status);
+
+    boolean existsByFoundItemAndLostItem_Reporter_IdAndStatus(Item foundItem, Long reporterId, MatchStatus status);
+
+    boolean existsByLostItemAndFoundItem_Reporter_IdAndStatus(Item lostItem, Long reporterId, MatchStatus status);
 }

--- a/src/main/java/com/zoopick/server/repository/LockerCommandRepository.java
+++ b/src/main/java/com/zoopick/server/repository/LockerCommandRepository.java
@@ -2,6 +2,7 @@ package com.zoopick.server.repository;
 
 import com.zoopick.server.entity.LockerCommand;
 import com.zoopick.server.entity.LockerCommandStatus;
+import com.zoopick.server.entity.LockerCommandType;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -13,4 +14,8 @@ public interface LockerCommandRepository extends JpaRepository<LockerCommand, Lo
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<LockerCommand> findFirstByLocker_IdAndStatusOrderByCreatedAtAsc(
             Long lockerId, LockerCommandStatus status);
+
+    // 해당 사물함에 내려진 가장 최신 명령을 조회 (주로 OPEN 명령을 내린 사람을 확인하기 위함)
+    Optional<LockerCommand> findFirstByLocker_IdAndCommandOrderByCreatedAtDesc(
+            Long lockerId, LockerCommandType command);
 }

--- a/src/main/java/com/zoopick/server/service/ItemPostService.java
+++ b/src/main/java/com/zoopick/server/service/ItemPostService.java
@@ -2,11 +2,10 @@ package com.zoopick.server.service;
 
 import com.zoopick.server.dto.item.*;
 import com.zoopick.server.entity.*;
+import com.zoopick.server.exception.DataNotFoundException;
+import com.zoopick.server.exception.ForbiddenException;
 import com.zoopick.server.mapper.ItemPostMapper;
-import com.zoopick.server.repository.BuildingRepository;
-import com.zoopick.server.repository.ItemPostRepository;
-import com.zoopick.server.repository.ItemRepository;
-import com.zoopick.server.repository.UserRepository;
+import com.zoopick.server.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -27,6 +26,7 @@ public class ItemPostService {
     private final UserRepository userRepository;
     private final ItemPostRepository itemPostRepository;
     private final BuildingRepository buildingRepository;
+    private final ItemMatchRepository itemMatchRepository;
     private final ItemPostMapper itemPostMapper;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -71,5 +71,26 @@ public class ItemPostService {
     public ItemPostRecord getItemPost(long id) {
         ItemPost itemPost = itemPostRepository.findByIdOrThrow(id);
         return itemPostMapper.toItemPostRecord(itemPost);
+    }
+
+    public ItemOwnerInfoResult getOwnerInfo(long userId, long itemId) {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> DataNotFoundException.from("물품", itemId));
+
+        // [QR-2] 인가 체크: 본인이 신고한 물품이거나, CONFIRMED 매칭된 상대방인지 확인
+        boolean isReporter = item.getReporter().getId().equals(userId);
+        boolean isMatchedFound = itemMatchRepository.existsByFoundItemAndLostItem_Reporter_IdAndStatus(
+                item, userId, MatchStatus.CONFIRMED);
+        boolean isMatchedLost = itemMatchRepository.existsByLostItemAndFoundItem_Reporter_IdAndStatus(
+                item, userId, MatchStatus.CONFIRMED);
+
+        if (!isReporter && !isMatchedFound && !isMatchedLost) {
+            throw new ForbiddenException(
+                    "물품 소유자 정보를 볼 권한이 없습니다.",
+                    "User " + userId + " is not authorized to see owner info of item " + itemId);
+        }
+
+        User owner = item.getReporter();
+        return new ItemOwnerInfoResult(owner.getNickname(), owner.getDepartment());
     }
 }

--- a/src/main/java/com/zoopick/server/service/LockerService.java
+++ b/src/main/java/com/zoopick/server/service/LockerService.java
@@ -3,10 +3,8 @@ package com.zoopick.server.service;
 import com.zoopick.server.entity.*;
 import com.zoopick.server.exception.BadRequestException;
 import com.zoopick.server.exception.DataNotFoundException;
-import com.zoopick.server.repository.ItemRepository;
-import com.zoopick.server.repository.LockerCommandRepository;
-import com.zoopick.server.repository.LockerRepository;
-import com.zoopick.server.repository.UserRepository;
+import com.zoopick.server.exception.ForbiddenException;
+import com.zoopick.server.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -24,10 +22,12 @@ public class LockerService {
     private final LockerCommandRepository commandRepository;
     private final ItemRepository itemRepository;
     private final UserRepository userRepository;
+    private final ItemMatchRepository itemMatchRepository;
 
     @Transactional
-    public LockerCommand requestUnlock(String email, Long lockerId, Long itemId) {
-        User user = userRepository.findBySchoolEmailOrThrow(email);
+    public LockerCommand requestUnlock(Long userId, Long lockerId, Long itemId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> DataNotFoundException.from("사용자", userId));
         Locker locker = lockerRepository.findById(lockerId)
                 .orElseThrow(() -> DataNotFoundException.from("사물함", lockerId));
 
@@ -40,15 +40,15 @@ public class LockerService {
         boolean isStorage = (locker.getCurrentItem() == null);
 
         if (isStorage) {
-            handleStorage(locker, itemId);
+            handleStorage(userId, locker, itemId);
         } else {
-            handleRetrieval(locker);
+            handleRetrieval(userId, locker);
         }
 
         return enqueue(user, locker, LockerCommandType.OPEN);
     }
 
-    private void handleStorage(Locker locker, Long itemId) {
+    private void handleStorage(Long userId, Locker locker, Long itemId) {
         if (itemId == null) {
             throw new BadRequestException(
                     "보관할 물품 정보가 필요합니다.",
@@ -57,6 +57,13 @@ public class LockerService {
 
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> DataNotFoundException.from("물품", itemId));
+
+        // [AUTH-1] 본인이 신고한 습득물인지 확인
+        if (!item.getReporter().getId().equals(userId)) {
+            throw new ForbiddenException(
+                    "본인이 신고한 물품만 보관할 수 있습니다.",
+                    "User " + userId + " is not the reporter of item " + itemId);
+        }
 
         if (item.getType() != ItemType.FOUND) {
             throw new BadRequestException(
@@ -73,12 +80,24 @@ public class LockerService {
         locker.setCurrentItem(item);
         item.setStatus(ItemStatus.IN_LOCKER);
 
-        log.info("[STORE] locker_id={} item_id={} 보관 요청",
-                locker.getId(), itemId);
+        log.info("[STORE] locker_id={} item_id={} user_id={} 보관 요청",
+                locker.getId(), itemId, userId);
     }
 
-    private void handleRetrieval(Locker locker) {
+    private void handleRetrieval(Long userId, Locker locker) {
         Item stored = locker.getCurrentItem();
+
+        // [AUTH-2] 권한 확인: 신고자 본인이거나, CONFIRMED 매칭된 소유자여야 함
+        boolean isReporter = stored.getReporter().getId().equals(userId);
+        boolean isMatchedOwner = itemMatchRepository.existsByFoundItemAndLostItem_Reporter_IdAndStatus(
+                stored, userId, MatchStatus.CONFIRMED);
+
+        if (!isReporter && !isMatchedOwner) {
+            throw new ForbiddenException(
+                    "물품을 회수할 권한이 없습니다.",
+                    "User " + userId + " has no permission to retrieve item " + stored.getId());
+        }
+
         LocalDateTime now = LocalDateTime.now();
 
         locker.setStatus(LockerStatus.EMPTY);
@@ -86,16 +105,28 @@ public class LockerService {
         stored.setStatus(ItemStatus.RETURNED);
         stored.setReturnedAt(now);
 
-        log.info("[RETRIEVE] locker_id={} item_id={} 회수 요청",
-                locker.getId(), stored.getId());
+        log.info("[RETRIEVE] locker_id={} item_id={} user_id={} 회수 요청",
+                locker.getId(), stored.getId(), userId);
     }
 
     @Transactional
-    public LockerCommand requestLock(String email, Long lockerId) {
-        User user = userRepository.findBySchoolEmailOrThrow(email);
+    public LockerCommand requestLock(Long userId, Long lockerId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> DataNotFoundException.from("사용자", userId));
         Locker locker = lockerRepository.findById(lockerId)
                 .orElseThrow(() -> DataNotFoundException.from("사물함", lockerId));
-        log.info("[CLOSE] locker_id={} 잠금 요청", lockerId);
+
+        // [AUTH-3] 잠금 권한 확인: 가장 최근에 이 사물함을 연(OPEN) 사람만 잠글 수 있음
+        commandRepository.findFirstByLocker_IdAndCommandOrderByCreatedAtDesc(lockerId, LockerCommandType.OPEN)
+                .ifPresent(lastOpenCmd -> {
+                    if (!lastOpenCmd.getIssuedBy().getId().equals(userId)) {
+                        throw new ForbiddenException(
+                                "사물함을 잠글 권한이 없습니다 (열었던 사용자만 가능).",
+                                "User " + userId + " is not the issuer of the last OPEN command");
+                    }
+                });
+
+        log.info("[CLOSE] locker_id={} user_id={} 잠금 요청", lockerId, userId);
         return enqueue(user, locker, LockerCommandType.CLOSE);
     }
 

--- a/src/main/java/com/zoopick/server/service/LockerService.java
+++ b/src/main/java/com/zoopick/server/service/LockerService.java
@@ -58,7 +58,7 @@ public class LockerService {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> DataNotFoundException.from("물품", itemId));
 
-        // [AUTH-1] 본인이 신고한 습득물인지 확인
+        //본인이 신고한 습득물인지 확인
         if (!item.getReporter().getId().equals(userId)) {
             throw new ForbiddenException(
                     "본인이 신고한 물품만 보관할 수 있습니다.",
@@ -87,7 +87,7 @@ public class LockerService {
     private void handleRetrieval(Long userId, Locker locker) {
         Item stored = locker.getCurrentItem();
 
-        // [AUTH-2] 권한 확인: 신고자 본인이거나, CONFIRMED 매칭된 소유자여야 함
+        //권한 확인: 신고자 본인이거나, CONFIRMED 매칭된 소유자여야 함
         boolean isReporter = stored.getReporter().getId().equals(userId);
         boolean isMatchedOwner = itemMatchRepository.existsByFoundItemAndLostItem_Reporter_IdAndStatus(
                 stored, userId, MatchStatus.CONFIRMED);
@@ -116,7 +116,7 @@ public class LockerService {
         Locker locker = lockerRepository.findById(lockerId)
                 .orElseThrow(() -> DataNotFoundException.from("사물함", lockerId));
 
-        // [AUTH-3] 잠금 권한 확인: 가장 최근에 이 사물함을 연(OPEN) 사람만 잠글 수 있음
+        //잠금 권한 확인: 가장 최근에 이 사물함을 연(OPEN) 사람만 잠글 수 있음
         commandRepository.findFirstByLocker_IdAndCommandOrderByCreatedAtDesc(lockerId, LockerCommandType.OPEN)
                 .ifPresent(lastOpenCmd -> {
                     if (!lastOpenCmd.getIssuedBy().getId().equals(userId)) {


### PR DESCRIPTION
 #19 
 1. 사물함 잠금 해제 (보관 / 회수)
  사물함을 열기 위한 요청을 큐에 등록합니다. 물품 ID(itemId)의 유무에 따라 보관(Storage)과 회수(Retrieval) 흐름으로 자동 분기됩니다.

   - URL: POST /api/lockers/{lockerId}/unlock
   - Authorization: Bearer Token (필수)
   - Parameters:
     - lockerId (Path, Long): 제어할 사물함의 고유 ID
   - Request Body (JSON):
     - 보관 시: { "itemId": 123 } (방금 등록한 습득물의 ID 필수)
     - 회수 시: Body 없음 또는 {}
   - 권한 정책 (Authorization):
     - 보관: itemId에 해당하는 습득물의 최초 신고자 본인만 가능
     - 회수: 사물함에 들어있는 물건의 최초 신고자이거나, 매칭이 확정(CONFIRMED)된 분실물 소유자만 가능
   - Response (200 OK):

```
      {
       "success": true,
        "command_id": 1,
        "command": "OPEN",
        "message": "자물쇠가 곧 열립니다"
      }

```
  2. 사물함 잠금
  열려있는 사물함을 다시 잠그기 위한 명령을 큐에 등록합니다.

   - URL: POST /api/lockers/{lockerId}/lock
   - Authorization: Bearer Token (필수)
   - Parameters:
     - lockerId (Path, Long): 제어할 사물함의 고유 ID
   - 권한 정책: 해당 사물함을 가장 마지막으로 열었던(OPEN 명령을 내렸던) 사용자만 잠글 수 있음
   - Response (200 OK):

  ```
    {
        "success": true,
        "command_id": 2,
        "command": "CLOSE",
        "message": "자물쇠가 곧 잠깁니다"
      }

```
 
  3. 물품 소유자 정보 조회 (QR 스캔용)
  사용자 앱에서 물품 소유자의 QR 코드를 스캔했을 때 호출하여 상대방의 닉네임과 학과 정보를 안전하게 가져옵니다.

   - URL: GET /api/items/{itemId}/owner-info
   - Authorization: Bearer Token (필수)
   - Parameters:
     - itemId (Path, Long): 조회할 물품의 고유 ID
   - 권한 정책: 해당 물품의 원래 주인이거나, 해당 물품과 확정(CONFIRMED) 매칭된 상대방만 조회 가능. 그 외 사용자가 스캔 시 403 Forbidden 반환.
   - Response (200 OK):

```
      {
        "success": true,
        "data": {
          "nickname": "김민준",
          "department": "컴퓨터공학과"
        },
        "error": null
      }
```


  4. [IoT 전용] 명령 폴링 (Polling)
  아두이노 R4가 2초마다 주기적으로 호출하여 자신에게 할당된 새로운 명령이 있는지 확인합니다.

   - URL: GET /api/lockers/{lockerId}/pending
   - Authorization: 없음 (기기 자체 통신 허용)
   - Parameters:
     - lockerId (Path, Long): 아두이노가 담당하는 사물함 ID
   - Response (200 OK):
     - 대기 중인 명령이 있을 때:

   ```
     {
          "command": "OPEN",
          "command_id": 1
        }
```
     - 대기 중인 명령이 없을 때:

  ```
      {
          "command": "NONE"
        }

```

  5. [IoT 전용] 명령 완료 보고 (ACK)
  아두이노가 솔레노이드 모터 제어를 완료한 후 백엔드에 성공적으로 수행했음을 알립니다. 이 호출을 받아야 백엔드에서 명령 상태가 COMPLETED로 확정됩니다.

   - URL: POST /api/lockers/{lockerId}/commands/{commandId}/ack
   - Authorization: 없음 (기기 자체 통신 허용)


Locker 컬럼 필요 

```
   INSERT INTO zoopick.lockers (id, status, current_item_id)
    VALUES (1, 'EMPTY', NULL);
```

Locker 번호는 1로 고정 

<img width="869" height="420" alt="스크린샷 2026-05-12 200354" src="https://github.com/user-attachments/assets/6a3d4159-2442-4271-8355-63723f742ff0" />
<img width="1835" height="109" alt="스크린샷 2026-05-12 202016" src="https://github.com/user-attachments/assets/cac1db9b-3d80-4ea6-9e55-cdc4541ff15f" />
<img width="417" height="107" alt="스크린샷 2026-05-12 202034" src="https://github.com/user-attachments/assets/34f74227-2ef5-4f11-8c91-f0d4bab11410" />
<img width="1066" height="95" alt="스크린샷 2026-05-12 202048" src="https://github.com/user-attachments/assets/d6cdbca1-3c9b-4885-a1b4-660dd5bb9d88" />
<img width="1068" height="658" alt="스크린샷 2026-05-12 202101" src="https://github.com/user-attachments/assets/022cb09d-8986-4ba4-8a38-08b4a6984ae5" />
