### PR TITLE
Refactor: 아이템 생성 이벤트 리스너 분리 및 비전 분석 로직 수정

### DIFF
--- a/src/main/java/com/zoopick/server/service/ItemPostEventListner.java
+++ b/src/main/java/com/zoopick/server/service/ItemPostEventListner.java
@@ -1,0 +1,22 @@
+package com.zoopick.server.service;
+
+import com.zoopick.server.dto.item.ItemCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ItemPostEventListner {
+    private final VisionService visionService;
+    //db에 commit한 이벤트를 받으면 실행
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleItemCreated(ItemCreatedEvent event) {
+        visionService.analyzeImage(event.itemId());
+    }
+}

--- a/src/main/java/com/zoopick/server/service/VisionService.java
+++ b/src/main/java/com/zoopick/server/service/VisionService.java
@@ -1,7 +1,6 @@
 package com.zoopick.server.service;
 
 import com.zoopick.server.config.FastApiProperties;
-import com.zoopick.server.dto.item.ItemCreatedEvent;
 import com.zoopick.server.dto.vision.VisionAnalyzeRequest;
 import com.zoopick.server.dto.vision.VisionAnalyzeResponse;
 import com.zoopick.server.entity.Item;
@@ -11,11 +10,8 @@ import com.zoopick.server.repository.ItemRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.client.RestClient;
 
 @Service
@@ -26,13 +22,6 @@ public class VisionService {
     private final FastApiProperties fastApiProperties;
     private final ItemRepository itemRepository;
     private final ItemMatchService itemMatchService;
-
-    //db에 commit한 이벤트를 받으면 실행
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleItemCreated(ItemCreatedEvent event) {
-        analyzeImage(event.itemId());
-    }
 
     @Transactional
     public void analyzeImage(Long itemId) {
@@ -54,8 +43,9 @@ public class VisionService {
             if (response == null) {
                 throw new DataNotFoundException("분석 결과", imageUrl);
             }
-            item.setCategory(response.getCategory());
-            item.setColor(response.getColor());
+            // Item Post 로직 오류로 인한 임시 주석처리
+            // item.setCategory(response.getCategory());
+            // item.setColor(response.getColor());
             item.setEmbedding(response.getEmbedding());
             itemRepository.save(item);
             itemMatchService.createMatch(item.getId());


### PR DESCRIPTION
## 📑 개요 (Description)
기존 `VisionService`에 강하게 결합되어 있던 이벤트 핸들링 로직을 별도의 리스너 클래스로 분리하여 관심사를 분리(Separation of Concerns)했습니다. 또한, 아이템 등록 프로세스의 안정성을 확보하기 위해 분석 결과 반영 로직 일부를 수정했습니다.

## 🚀 주요 변경 사항 (Changes)

### 1. 이벤트 리스너 클래스 분리
- **신규 클래스 추가**: `ItemPostEventListner`를 생성하여 `@TransactionalEventListener` 로직을 이관했습니다.
- **관심사 분리**: `VisionService`는 순수 비즈니스 로직(이미지 분석 및 데이터 저장)에만 집중하고, 이벤트 수신 및 비동기 호출 처리는 리스너가 담당하도록 구조를 개선했습니다.

### 2. 비전 분석 로직 수정 (`VisionService`)
- **임시 주석 처리**: 현재 아이템 등록(Post) 로직의 오류로 인해 분석 결과 중 `category`와 `color`를 엔티티에 세팅하는 부분을 임시로 주석 처리했습니다.
- **기능 유지**: `embedding` 추출 및 저장, 그리고 `itemMatchService.createMatch`를 통한 물품 매칭 로직은 기존과 동일하게 수행됩니다.

### 3. 코드 정리 및 최적화
- `VisionService` 내 불필요한 의존성(ItemCreatedEvent 등) 및 미사용 임포트 제거.
- 코드 가독성 향상을 위한 로깅 코드 정비.

## 🔍 테스트 결과 (Testing)
- [x] 아이템 저장 후 DB 커밋 시점에 `ItemCreatedEvent`가 정상적으로 발행되는지 확인.
- [x] `ItemPostEventListner`에서 이벤트를 수신하여 비동기(`@Async`)로 `analyzeImage`를 호출하는지 확인.
- [x] 비전 분석 결과 중 `embedding` 정보가 DB에 정상적으로 업데이트되는지 확인.

## 📌 참고 사항
- 아이템 Post 로직의 근본적인 오류가 해결된 후, 주석 처리된 `category`, `color` 설정 부분을 다시 활성화할 예정입니다.