### PR TITLE
Feat: 웹소켓 채팅 READ 타입 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,11 @@
             <artifactId>hibernate-vector</artifactId>
             <version>7.2.7.Final</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.zxing</groupId>
+            <artifactId>javase</artifactId>
+            <version>3.5.4</version>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/com/zoopick/server/config/RedisConfig.java
+++ b/src/main/java/com/zoopick/server/config/RedisConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.JacksonJsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -16,6 +17,22 @@ public class RedisConfig {
         redisTemplate.setConnectionFactory(connectionFactory);
 
         JacksonJsonRedisSerializer<EmailAuth> serializer = new JacksonJsonRedisSerializer<>(EmailAuth.class);
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(serializer);
+        redisTemplate.setHashValueSerializer(serializer);
+        redisTemplate.afterPropertiesSet();
+
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, byte[]> qrCodeRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        RedisSerializer<byte[]> serializer = RedisSerializer.byteArray();
 
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());

--- a/src/main/java/com/zoopick/server/controller/ChatRoomController.java
+++ b/src/main/java/com/zoopick/server/controller/ChatRoomController.java
@@ -74,6 +74,16 @@ public class ChatRoomController {
         return ResponseEntity.status(httpStatue).body(CommonResponse.success(result));
     }
 
+    @PostMapping("/by-owner")
+    public ResponseEntity<CommonResponse<CreateChatRoomResult>> createChatRoomByOwner(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestBody @Valid CreateChatRoomByOwnerRequest request
+    ) {
+        CreateChatRoomResult result = chatRoomService.createChatRoomByOwner(principal.id(), request.getOwnerId());
+        HttpStatusCode httpStatue = result.isCreated() ? HttpStatus.CREATED : HttpStatus.OK;
+        return ResponseEntity.status(httpStatue).body(CommonResponse.success(result));
+    }
+
     @Operation(summary = "채팅방 단건 조회", description = "채팅방 ID로 채팅방 상세 정보를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "채팅방 조회 성공"),

--- a/src/main/java/com/zoopick/server/controller/ChatRoomController.java
+++ b/src/main/java/com/zoopick/server/controller/ChatRoomController.java
@@ -1,6 +1,5 @@
 package com.zoopick.server.controller;
 
-import com.google.firebase.messaging.FirebaseMessagingException;
 import com.zoopick.server.dto.CommonResponse;
 import com.zoopick.server.dto.chat.*;
 import com.zoopick.server.security.UserPrincipal;
@@ -74,6 +73,14 @@ public class ChatRoomController {
         return ResponseEntity.status(httpStatue).body(CommonResponse.success(result));
     }
 
+    @Operation(summary = "소유자 기준 채팅방 생성", description = "QR 스캔 등으로 전달받은 소유자 사용자 ID를 기준으로 채팅방을 생성하거나 기존 채팅방을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "기존 채팅방"),
+            @ApiResponse(responseCode = "201", description = "채팅방 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청값"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "404", description = "상대 사용자를 찾을 수 없음")
+    })
     @PostMapping("/by-owner")
     public ResponseEntity<CommonResponse<CreateChatRoomResult>> createChatRoomByOwner(
             @AuthenticationPrincipal UserPrincipal principal,
@@ -133,7 +140,7 @@ public class ChatRoomController {
             @Parameter(description = "메시지를 전송할 채팅방 ID", example = "1")
             @PathVariable long roomId,
             @RequestBody @Valid SendMessageRequest sendMessageRequest
-    ) throws FirebaseMessagingException {
+    ) {
         chatRoomService.sendMessageWithNotification(principal.id(), roomId, sendMessageRequest.getMessage());
         return ResponseEntity.ok(CommonResponse.success("done"));
     }
@@ -152,7 +159,7 @@ public class ChatRoomController {
             @Parameter(description = "종료할 채팅방 ID", example = "1")
             @PathVariable long roomId,
             @RequestBody @Valid CloseChatRoomRequest closeChatRoomRequest
-    ) throws FirebaseMessagingException {
+    ) {
         chatRoomService.closeChatRoom(principal.id(), roomId, closeChatRoomRequest.getReason());
         return ResponseEntity.ok(CommonResponse.success("성공"));
     }
@@ -170,7 +177,7 @@ public class ChatRoomController {
             @AuthenticationPrincipal UserPrincipal principal,
             @Parameter(description = "재개할 채팅방 ID", example = "1")
             @PathVariable long roomId
-    ) throws FirebaseMessagingException {
+    ) {
         chatRoomService.reopenChatRoom(principal.id(), roomId);
         return ResponseEntity.ok(CommonResponse.success("성공"));
     }

--- a/src/main/java/com/zoopick/server/controller/ProfileController.java
+++ b/src/main/java/com/zoopick/server/controller/ProfileController.java
@@ -6,6 +6,7 @@ import com.zoopick.server.security.UserPrincipal;
 import com.zoopick.server.service.ProfileService;
 import com.zoopick.server.service.QrCodeService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -50,6 +51,15 @@ public class ProfileController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "내 QR 코드 이미지 조회", description = "현재 로그인한 사용자의 QR 코드 PNG 이미지를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "QR 코드 조회 성공",
+                    content = @Content(mediaType = MediaType.IMAGE_PNG_VALUE)
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
+    })
     @GetMapping(value = "/me/qr", produces = MediaType.IMAGE_PNG_VALUE)
     public ResponseEntity<byte[]> getQRCode(@AuthenticationPrincipal UserPrincipal principal) {
         byte[] imageBytes = qrCodeService.createUserQrCode(principal.id());

--- a/src/main/java/com/zoopick/server/controller/ProfileController.java
+++ b/src/main/java/com/zoopick/server/controller/ProfileController.java
@@ -2,15 +2,18 @@ package com.zoopick.server.controller;
 
 import com.zoopick.server.dto.profile.ProfileSummaryResponse;
 import com.zoopick.server.dto.profile.ProfileUpdateRequest;
+import com.zoopick.server.security.UserPrincipal;
 import com.zoopick.server.service.ProfileService;
+import com.zoopick.server.service.QrCodeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Profile API", description = "사용자 프로필 관련 API")
@@ -20,15 +23,15 @@ import org.springframework.web.bind.annotation.*;
 public class ProfileController {
 
     private final ProfileService profileService;
+    private final QrCodeService qrCodeService;
 
     @Operation(summary = "내 프로필 요약 조회", description = "현재 로그인한 사용자의 프로필 기본 정보와 활동 요약(게시글 수, 채팅방 수, 안 읽은 알림 수)을 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "프로필 조회 성공")
     })
     @GetMapping("/me")
-    public ResponseEntity<ProfileSummaryResponse> getMyProfile(Authentication authentication) {
-        String email = authentication.getName();
-        ProfileSummaryResponse response = profileService.getProfileSummary(email);
+    public ResponseEntity<ProfileSummaryResponse> getMyProfile(@AuthenticationPrincipal UserPrincipal principal) {
+        ProfileSummaryResponse response = profileService.getProfileSummary(principal.email());
         return ResponseEntity.ok(response);
     }
 
@@ -40,10 +43,18 @@ public class ProfileController {
     })
     @PutMapping("/me")
     public ResponseEntity<Void> updateMyProfile(
-            Authentication authentication,
-            @RequestBody @Valid ProfileUpdateRequest request) { // @Valid 적용
-
-        profileService.updateProfile(authentication.getName(), request);
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestBody @Valid ProfileUpdateRequest request
+    ) { // @Valid 적용
+        profileService.updateProfile(principal.email(), request);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping(value = "/me/qr", produces = MediaType.IMAGE_PNG_VALUE)
+    public ResponseEntity<byte[]> getQRCode(@AuthenticationPrincipal UserPrincipal principal) {
+        byte[] imageBytes = qrCodeService.createUserQrCode(principal.id());
+        return ResponseEntity.ok()
+                .contentType(MediaType.IMAGE_PNG)
+                .body(imageBytes);
     }
 }

--- a/src/main/java/com/zoopick/server/controller/ScanController.java
+++ b/src/main/java/com/zoopick/server/controller/ScanController.java
@@ -1,0 +1,28 @@
+package com.zoopick.server.controller;
+
+import com.zoopick.server.dto.CommonResponse;
+import com.zoopick.server.dto.scan.ScanOwnerResult;
+import com.zoopick.server.service.ProfileService;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/scan")
+@NullMarked
+public class ScanController {
+    private final ProfileService profileService;
+
+    public ScanController(ProfileService profileService) {
+        this.profileService = profileService;
+    }
+
+    @GetMapping("/owner/{userId}")
+    public ResponseEntity<CommonResponse<ScanOwnerResult>> scanOwner(@PathVariable long userId) {
+        String nickname = profileService.findNickname(userId);
+        return ResponseEntity.ok(CommonResponse.success(new ScanOwnerResult(userId, nickname)));
+    }
+}

--- a/src/main/java/com/zoopick/server/controller/ScanController.java
+++ b/src/main/java/com/zoopick/server/controller/ScanController.java
@@ -3,6 +3,13 @@ package com.zoopick.server.controller;
 import com.zoopick.server.dto.CommonResponse;
 import com.zoopick.server.dto.scan.ScanOwnerResult;
 import com.zoopick.server.service.ProfileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/scan")
 @NullMarked
+@Tag(name = "Scan API", description = "QR 스캔 기반 사용자 조회 API")
 public class ScanController {
     private final ProfileService profileService;
 
@@ -20,8 +28,23 @@ public class ScanController {
         this.profileService = profileService;
     }
 
+    @Operation(
+            summary = "QR 소유자 조회",
+            description = "QR 코드에 포함된 사용자 식별값으로 소유자의 기본 정보를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = ScanOwnerResult.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
     @GetMapping("/owner/{userId}")
-    public ResponseEntity<CommonResponse<ScanOwnerResult>> scanOwner(@PathVariable long userId) {
+    public ResponseEntity<CommonResponse<ScanOwnerResult>> scanOwner(
+            @Parameter(description = "QR 코드에 담긴 사용자 ID", example = "1")
+            @PathVariable long userId
+    ) {
         String nickname = profileService.findNickname(userId);
         return ResponseEntity.ok(CommonResponse.success(new ScanOwnerResult(userId, nickname)));
     }

--- a/src/main/java/com/zoopick/server/dto/chat/CreateChatRoomByOwnerRequest.java
+++ b/src/main/java/com/zoopick/server/dto/chat/CreateChatRoomByOwnerRequest.java
@@ -1,0 +1,14 @@
+package com.zoopick.server.dto.chat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class CreateChatRoomByOwnerRequest {
+    @JsonProperty("owner_id")
+    private Long ownerId;
+}

--- a/src/main/java/com/zoopick/server/dto/notification/NotificationRecord.java
+++ b/src/main/java/com/zoopick/server/dto/notification/NotificationRecord.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
-import java.util.Map;
 
 /**
  * 알림 하나의 데이터
@@ -33,7 +32,7 @@ public class NotificationRecord {
                     LockerReadyPayload.class
             }
     )
-    private Map<String, Object> payload;
+    private NotificationPayload payload;
 
     @JsonProperty("read_at")
     @Schema(description = "읽음 시각", example = "2026-05-09T14:30:00")

--- a/src/main/java/com/zoopick/server/dto/scan/ScanOwnerResult.java
+++ b/src/main/java/com/zoopick/server/dto/scan/ScanOwnerResult.java
@@ -1,0 +1,15 @@
+package com.zoopick.server.dto.scan;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ScanOwnerResult {
+    @JsonProperty("owner_id")
+    private Long ownerId;
+    private String nickname;
+}

--- a/src/main/java/com/zoopick/server/mapper/notification/NotificationMapper.java
+++ b/src/main/java/com/zoopick/server/mapper/notification/NotificationMapper.java
@@ -6,24 +6,24 @@ import com.zoopick.server.dto.notification.NotificationRecord;
 import com.zoopick.server.entity.User;
 import com.zoopick.server.entity.ZoopickNotification;
 import com.zoopick.server.service.notification.SendNotificationCommand;
+import com.zoopick.server.service.notification.payload.NotificationPayload;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 public class NotificationMapper {
     private final ObjectMapper objectMapper;
+    private final NotificationPayloadMapper notificationPayloadMapper;
 
     public NotificationRecord toNotificationResponse(ZoopickNotification notification) {
         NotificationRecord notificationRecord = new NotificationRecord();
         notificationRecord.setId(notification.getId());
         notificationRecord.setType(notification.getType());
         notificationRecord.setCreatedAt(notification.getCreatedAt());
-        Map<String, Object> payload = objectMapper.convertValue(notification.getPayload(), new TypeReference<>() {
-        });
+        NotificationPayload payload = notificationPayloadMapper.toNotificationPayload(notification.getPayload(), notification.getType());
         notificationRecord.setPayload(payload);
         notificationRecord.setReadAt(notification.getReadAt());
 

--- a/src/main/java/com/zoopick/server/mapper/notification/NotificationPayloadMapper.java
+++ b/src/main/java/com/zoopick/server/mapper/notification/NotificationPayloadMapper.java
@@ -1,0 +1,46 @@
+package com.zoopick.server.mapper.notification;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zoopick.server.entity.NotificationType;
+import com.zoopick.server.exception.InternalServerException;
+import com.zoopick.server.service.notification.payload.*;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@NullMarked
+public class NotificationPayloadMapper {
+    private final Map<NotificationType, Class<? extends NotificationPayload>> payloadTypes = Map.of(
+            NotificationType.CHAT_MESSAGE, ChatMessagePayload.class,
+            NotificationType.ITEM_RETURNED, ItemReturnedPayload.class,
+            NotificationType.LOCKER_READY, LockerReadyPayload.class,
+            NotificationType.THEFT_SUSPECTED, TheftSuspectedPayload.class,
+            NotificationType.MATCH_FOUND, MatchFoundPayload.class
+    );
+
+    private final ObjectMapper objectMapper;
+
+    public <T extends NotificationPayload> T toNotificationPayload(JsonNode jsonNode, Class<T> payloadType) {
+        try {
+            return objectMapper.convertValue(jsonNode, payloadType);
+        } catch (IllegalArgumentException exception) {
+            throw new InternalServerException("Failed to convert payload " + jsonNode, exception);
+        }
+    }
+
+    public NotificationPayload toNotificationPayload(Object object, NotificationType type) {
+        try {
+            Class<? extends NotificationPayload> payloadType = payloadTypes.get(type);
+            if (!payloadTypes.containsKey(type))
+                throw new UnsupportedOperationException("Unsupported notification type : " + type);
+            return objectMapper.convertValue(object, payloadType);
+        } catch (IllegalArgumentException exception) {
+            throw new InternalServerException("Failed to convert payload " + object, exception);
+        }
+    }
+}

--- a/src/main/java/com/zoopick/server/mapper/notification/SendNotificationRequestMapper.java
+++ b/src/main/java/com/zoopick/server/mapper/notification/SendNotificationRequestMapper.java
@@ -1,31 +1,20 @@
 package com.zoopick.server.mapper.notification;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zoopick.server.dto.notification.SendNotificationRequest;
 import com.zoopick.server.entity.NotificationType;
 import com.zoopick.server.exception.BadRequestException;
 import com.zoopick.server.exception.InternalServerException;
 import com.zoopick.server.service.notification.SendNotificationCommand;
-import com.zoopick.server.service.notification.payload.*;
+import com.zoopick.server.service.notification.payload.NotificationPayload;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.stereotype.Component;
-
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 @NullMarked
 public class SendNotificationRequestMapper {
-    private final Map<NotificationType, Class<? extends NotificationPayload>> payloadTypes = Map.of(
-            NotificationType.CHAT_MESSAGE, ChatMessagePayload.class,
-            NotificationType.ITEM_RETURNED, ItemReturnedPayload.class,
-            NotificationType.LOCKER_READY, LockerReadyPayload.class,
-            NotificationType.THEFT_SUSPECTED, TheftSuspectedPayload.class,
-            NotificationType.MATCH_FOUND, MatchFoundPayload.class
-    );
-
-    private final ObjectMapper objectMapper;
+    private final NotificationPayloadMapper notificationPayloadMapper;
 
     /**
      * {@linkplain SendNotificationRequest}를 {@linkplain SendNotificationCommand}로 변환합니다.
@@ -38,10 +27,7 @@ public class SendNotificationRequestMapper {
     public SendNotificationCommand toCommand(SendNotificationRequest request) {
         try {
             NotificationType type = request.getType();
-            if (!payloadTypes.containsKey(type))
-                throw new UnsupportedOperationException("Unsupported notification type : " + type);
-            Class<? extends NotificationPayload> payloadType = payloadTypes.get(type);
-            NotificationPayload payload = objectMapper.convertValue(request.getPayload(), payloadType);
+            NotificationPayload payload = notificationPayloadMapper.toNotificationPayload(request.getPayload(), type);
             return new SendNotificationCommand(request.getTitle(), request.getBody(), payload);
         } catch (IllegalArgumentException exception) {
             throw new BadRequestException("잘못된 요청입니다.", request.getPayload() + " is not readable");

--- a/src/main/java/com/zoopick/server/qr/QrCodeGenerator.java
+++ b/src/main/java/com/zoopick/server/qr/QrCodeGenerator.java
@@ -1,0 +1,89 @@
+package com.zoopick.server.qr;
+
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.WriterException;
+import com.google.zxing.client.j2se.MatrixToImageWriter;
+import com.google.zxing.common.BitMatrix;
+import com.google.zxing.qrcode.QRCodeWriter;
+import com.zoopick.server.exception.InternalServerException;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.stereotype.Component;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+@Component
+@NullMarked
+public class QrCodeGenerator {
+    private static final int QR_SIZE = 200;
+    private static final int TOP_PADDING = 16;
+    private static final int BOTTOM_PADDING = 16;
+    private static final int SIDE_PADDING = 16;
+    private static final Font TITLE_FONT = new Font("SansSerif", Font.BOLD, 24);
+    private static final String TITLE = "Zoopick";
+
+    public byte[] generate(String content) {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            QRCodeWriter qrCodeWriter = new QRCodeWriter();
+            BitMatrix bitMatrix = qrCodeWriter.encode(content, BarcodeFormat.QR_CODE, QR_SIZE, QR_SIZE);
+
+            BufferedImage qrImage = MatrixToImageWriter.toBufferedImage(bitMatrix);
+            BufferedImage image = createImageWithTitle(qrImage);
+
+            ImageIO.write(image, "PNG", outputStream);
+            return outputStream.toByteArray();
+        } catch (WriterException exception) {
+            throw new InternalServerException("Failed to encode QR code image", exception);
+        } catch (IOException exception) {
+            throw new InternalServerException("Failed to write QR code image", exception);
+        }
+    }
+
+    private BufferedImage createImageWithTitle(BufferedImage qrImage) {
+        FontMetrics fontMetrics = createFontMetrics();
+        int titleHeight = fontMetrics.getAscent() + fontMetrics.getDescent();
+        int gapBetweenTitleAndQr = 12;
+
+        BufferedImage canvas = new BufferedImage(
+                qrImage.getWidth() + (SIDE_PADDING * 2),
+                qrImage.getHeight() + TOP_PADDING + titleHeight + gapBetweenTitleAndQr + BOTTOM_PADDING,
+                BufferedImage.TYPE_INT_RGB
+        );
+
+        Graphics2D graphics = canvas.createGraphics();
+        try {
+            graphics.setColor(Color.WHITE);
+            graphics.fillRect(0, 0, canvas.getWidth(), canvas.getHeight());
+            graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+
+            graphics.setColor(Color.BLACK);
+            graphics.setFont(TITLE_FONT);
+
+            int titleX = (canvas.getWidth() - fontMetrics.stringWidth(TITLE)) / 2;
+            int titleY = TOP_PADDING + fontMetrics.getAscent();
+            graphics.drawString(TITLE, titleX, titleY);
+
+            int qrY = TOP_PADDING + titleHeight + gapBetweenTitleAndQr;
+            graphics.drawImage(qrImage, SIDE_PADDING, qrY, null);
+        } finally {
+            graphics.dispose();
+        }
+
+        return canvas;
+    }
+
+    private FontMetrics createFontMetrics() {
+        BufferedImage image = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            graphics.setFont(TITLE_FONT);
+            return graphics.getFontMetrics();
+        } finally {
+            graphics.dispose();
+        }
+    }
+}

--- a/src/main/java/com/zoopick/server/repository/ChatMessageRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ChatMessageRepository.java
@@ -2,12 +2,16 @@ package com.zoopick.server.repository;
 
 import com.zoopick.server.dto.chat.MessageFilter;
 import com.zoopick.server.entity.ChatMessage;
+import com.zoopick.server.entity.ChatRoom;
+import com.zoopick.server.entity.User;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>, JpaSpecificationExecutor<ChatMessage> {
@@ -33,4 +37,6 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>,
         return Specification.where(after(filter.getStartTime()))
                 .and(before(filter.getEndTime()));
     }
+
+    List<ChatMessage> findByRoomAndSenderIsNot(@NotNull ChatRoom room, @NotNull User sender);
 }

--- a/src/main/java/com/zoopick/server/repository/ChatRoomRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ChatRoomRepository.java
@@ -27,4 +27,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     }
 
     long countByOwnerIdOrFinderId(Long ownerId, Long finderId);
+
+    Optional<ChatRoom> findByOwnerIdAndFinderIdIs(long ownerId, long finderId);
 }

--- a/src/main/java/com/zoopick/server/repository/NotificationRepository.java
+++ b/src/main/java/com/zoopick/server/repository/NotificationRepository.java
@@ -1,5 +1,6 @@
 package com.zoopick.server.repository;
 
+import com.zoopick.server.entity.NotificationType;
 import com.zoopick.server.entity.ZoopickNotification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -13,4 +14,6 @@ public interface NotificationRepository extends JpaRepository<ZoopickNotificatio
     List<ZoopickNotification> findByUserIdAndReadAtIsNullOrderByCreatedAtDesc(Long userId);
 
     long countByUserIdAndReadAtIsNull(Long userId);
+
+    List<ZoopickNotification> findAllByUserIdAndType(Long userId, NotificationType type);
 }

--- a/src/main/java/com/zoopick/server/repository/QrCodeCacheRepository.java
+++ b/src/main/java/com/zoopick/server/repository/QrCodeCacheRepository.java
@@ -1,0 +1,44 @@
+package com.zoopick.server.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+@Component
+@RequiredArgsConstructor
+@NullMarked
+public class QrCodeCacheRepository {
+    private static final long QR_CODE_TTL = 3;
+    private static final String QR_CODE_KEY_PREFIX = "qrCode:";
+
+    private final RedisTemplate<String, byte[]> redisTemplate;
+
+    private static String qrCodeKey(String key) {
+        return QR_CODE_KEY_PREFIX + key;
+    }
+
+    public Optional<byte[]> get(String key) {
+        return Optional.ofNullable(
+                redisTemplate.opsForValue()
+                        .get(qrCodeKey(key))
+        );
+    }
+
+    public byte[] computeIfAbsent(String key, Function<String, byte[]> generator) {
+        return get(key).orElseGet(() -> {
+            byte[] bytes = generator.apply(key);
+            redisTemplate.opsForValue().set(
+                    qrCodeKey(key),
+                    bytes,
+                    QR_CODE_TTL,
+                    TimeUnit.MINUTES
+            );
+            return bytes;
+        });
+    }
+}

--- a/src/main/java/com/zoopick/server/service/ChatRoomService.java
+++ b/src/main/java/com/zoopick/server/service/ChatRoomService.java
@@ -5,10 +5,8 @@ import com.zoopick.server.entity.*;
 import com.zoopick.server.exception.BadRequestException;
 import com.zoopick.server.mapper.ChatMessageMapper;
 import com.zoopick.server.mapper.ChatRoomMapper;
-import com.zoopick.server.repository.ChatMessageRepository;
-import com.zoopick.server.repository.ChatRoomRepository;
-import com.zoopick.server.repository.ItemRepository;
-import com.zoopick.server.repository.UserRepository;
+import com.zoopick.server.mapper.notification.NotificationPayloadMapper;
+import com.zoopick.server.repository.*;
 import com.zoopick.server.service.notification.NotificationService;
 import com.zoopick.server.service.notification.SendNotificationCommand;
 import com.zoopick.server.service.notification.payload.ChatMessagePayload;
@@ -34,6 +32,8 @@ public class ChatRoomService {
     private final NotificationService notificationService;
     private final ChatMessageMapper chatMessageMapper;
     private final ChatRoomMapper chatRoomMapper;
+    private final NotificationRepository notificationRepository;
+    private final NotificationPayloadMapper notificationPayloadMapper;
 
     @Transactional
     public CreateChatRoomResult createChatRoom(long requesterId, CreateChatRoomRequest createChatRoomRequest) {
@@ -204,6 +204,17 @@ public class ChatRoomService {
         if (finder.getId().equals(sender.getId()))
             return owner;
         return finder;
+    }
+
+    public void readChatMessages(long userId, long chatRoomId) {
+        User user = userRepository.findByIdOrThrow(userId);
+        ChatRoom chatRoom = chatRoomRepository.findByIdOrThrow(chatRoomId);
+        verifyParticipant(chatRoom, user);
+
+        List<ChatMessage> messages = chatMessageRepository.findByRoomAndSenderIsNot(chatRoom, user);
+        messages.forEach(message -> message.setReadAt(LocalDateTime.now()));
+        chatMessageRepository.saveAll(messages);
+        notificationService.markAllChatsAsRead(userId, chatRoomId);
     }
 
     @Transactional

--- a/src/main/java/com/zoopick/server/service/ChatRoomService.java
+++ b/src/main/java/com/zoopick/server/service/ChatRoomService.java
@@ -45,13 +45,33 @@ public class ChatRoomService {
         User counterpart = userRepository.findByIdOrThrow(createChatRoomRequest.getCounterpartId());
 
         Optional<ChatRoom> existingChatRoom = chatRoomRepository.findByParticipantIdAndItemIdIs(requesterId, itemId);
-        if (existingChatRoom.isPresent())
+        if (existingChatRoom.isPresent()) {
+            existingChatRoom.get().setStatus(ChatRoomStatus.OPEN);
             return new CreateChatRoomResult(false, chatRoomMapper.toChatRoomRecord(existingChatRoom.get()));
+        }
 
         ChatRoom chatRoom = ChatRoom.builder()
                 .item(item)
                 .owner(resolveOwner(item.getType(), requester, counterpart))
                 .finder(resolveFinder(item.getType(), requester, counterpart))
+                .build();
+        ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
+        return new CreateChatRoomResult(true, chatRoomMapper.toChatRoomRecord(savedChatRoom));
+    }
+
+    public CreateChatRoomResult createChatRoomByOwner(long requesterId, long ownerId) {
+        User requester = userRepository.findByIdOrThrow(requesterId);
+        User owner = userRepository.findByIdOrThrow(ownerId);
+
+        Optional<ChatRoom> existingChatRoom = chatRoomRepository.findByOwnerIdAndFinderIdIs(ownerId, requesterId);
+        if (existingChatRoom.isPresent()) {
+            existingChatRoom.get().setStatus(ChatRoomStatus.OPEN);
+            return new CreateChatRoomResult(false, chatRoomMapper.toChatRoomRecord(existingChatRoom.get()));
+        }
+
+        ChatRoom chatRoom = ChatRoom.builder()
+                .owner(owner)
+                .finder(requester)
                 .build();
         ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
         return new CreateChatRoomResult(true, chatRoomMapper.toChatRoomRecord(savedChatRoom));

--- a/src/main/java/com/zoopick/server/service/ChatRoomService.java
+++ b/src/main/java/com/zoopick/server/service/ChatRoomService.java
@@ -5,8 +5,10 @@ import com.zoopick.server.entity.*;
 import com.zoopick.server.exception.BadRequestException;
 import com.zoopick.server.mapper.ChatMessageMapper;
 import com.zoopick.server.mapper.ChatRoomMapper;
-import com.zoopick.server.mapper.notification.NotificationPayloadMapper;
-import com.zoopick.server.repository.*;
+import com.zoopick.server.repository.ChatMessageRepository;
+import com.zoopick.server.repository.ChatRoomRepository;
+import com.zoopick.server.repository.ItemRepository;
+import com.zoopick.server.repository.UserRepository;
 import com.zoopick.server.service.notification.NotificationService;
 import com.zoopick.server.service.notification.SendNotificationCommand;
 import com.zoopick.server.service.notification.payload.ChatMessagePayload;
@@ -32,8 +34,6 @@ public class ChatRoomService {
     private final NotificationService notificationService;
     private final ChatMessageMapper chatMessageMapper;
     private final ChatRoomMapper chatRoomMapper;
-    private final NotificationRepository notificationRepository;
-    private final NotificationPayloadMapper notificationPayloadMapper;
 
     @Transactional
     public CreateChatRoomResult createChatRoom(long requesterId, CreateChatRoomRequest createChatRoomRequest) {
@@ -206,6 +206,7 @@ public class ChatRoomService {
         return finder;
     }
 
+    @Transactional
     public void readChatMessages(long userId, long chatRoomId) {
         User user = userRepository.findByIdOrThrow(userId);
         ChatRoom chatRoom = chatRoomRepository.findByIdOrThrow(chatRoomId);

--- a/src/main/java/com/zoopick/server/service/ProfileService.java
+++ b/src/main/java/com/zoopick/server/service/ProfileService.java
@@ -39,6 +39,11 @@ public class ProfileService {
         );
     }
 
+    public String findNickname(long userId) {
+        User user = userRepository.findByIdOrThrow(userId);
+        return user.getNickname();
+    }
+
     @Transactional
     public void updateProfile(String email, ProfileUpdateRequest request) {
         User user = userRepository.findBySchoolEmailOrThrow(email);

--- a/src/main/java/com/zoopick/server/service/QrCodeService.java
+++ b/src/main/java/com/zoopick/server/service/QrCodeService.java
@@ -1,0 +1,35 @@
+package com.zoopick.server.service;
+
+import com.zoopick.server.entity.User;
+import com.zoopick.server.qr.QrCodeGenerator;
+import com.zoopick.server.repository.QrCodeCacheRepository;
+import com.zoopick.server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@NullMarked
+public class QrCodeService {
+    private final UserRepository userRepository;
+    private final QrCodeGenerator qrCodeGenerator;
+    private final QrCodeCacheRepository qrCodeCacheRepository;
+    @Value("${zoopick.base-url}")
+    private String baseUrl;
+
+    private String createUserQrContent(User user) {
+        return baseUrl + "/scan/owner/" + user.getId();
+    }
+
+    public byte[] createUserQrCode(long userId) {
+        User user = userRepository.findByIdOrThrow(userId);
+        String content = createUserQrContent(user);
+        return createQRCode(content);
+    }
+
+    public byte[] createQRCode(String content) {
+        return qrCodeCacheRepository.computeIfAbsent(content, qrCodeGenerator::generate);
+    }
+}

--- a/src/main/java/com/zoopick/server/service/notification/NotificationService.java
+++ b/src/main/java/com/zoopick/server/service/notification/NotificationService.java
@@ -4,15 +4,18 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zoopick.server.dto.notification.ChangeReadStatusResult;
 import com.zoopick.server.dto.notification.NotificationRecord;
+import com.zoopick.server.entity.NotificationType;
 import com.zoopick.server.entity.User;
 import com.zoopick.server.entity.ZoopickNotification;
 import com.zoopick.server.exception.BadRequestException;
 import com.zoopick.server.exception.DataNotFoundException;
 import com.zoopick.server.mapper.notification.NotificationMapper;
+import com.zoopick.server.mapper.notification.NotificationPayloadMapper;
 import com.zoopick.server.repository.NotificationRepository;
 import com.zoopick.server.repository.UserRepository;
 import com.zoopick.server.service.notification.event.FcmMessageRequest;
 import com.zoopick.server.service.notification.event.NotificationDispatchRequestedEvent;
+import com.zoopick.server.service.notification.payload.ChatMessagePayload;
 import com.zoopick.server.service.notification.payload.NotificationPayload;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +38,7 @@ public class NotificationService {
     private final NotificationMapper notificationMapper;
     private final ObjectMapper objectMapper;
     private final ApplicationEventPublisher eventPublisher;
+    private final NotificationPayloadMapper notificationPayloadMapper;
 
     public void register(long userId, String fcmToken) {
         User user = userRepository.findByIdOrThrow(userId);
@@ -108,6 +112,21 @@ public class NotificationService {
 
     public List<NotificationRecord> getUnreadNotifications(long userId) {
         return findNotificationsWith(userId, notificationRepository::findByUserIdAndReadAtIsNullOrderByCreatedAtDesc);
+    }
+
+    public void markAllChatsAsRead(long userId, long roomId) {
+        List<ZoopickNotification> notifications = notificationRepository.findAllByUserIdAndType(userId, NotificationType.CHAT_MESSAGE);
+        for (ZoopickNotification notification : notifications) {
+            if (notificationFromChatRoom(notification, roomId)) {
+                notification.setReadAt(LocalDateTime.now());
+            }
+        }
+        notificationRepository.saveAll(notifications);
+    }
+
+    private boolean notificationFromChatRoom(ZoopickNotification notification, long roomId) {
+        ChatMessagePayload payload = notificationPayloadMapper.toNotificationPayload(notification.getPayload(), ChatMessagePayload.class);
+        return payload.roomId() == roomId;
     }
 
     private List<NotificationRecord> findNotificationsWith(long userId, Function<Long, List<ZoopickNotification>> repositoryAccessor) {

--- a/src/main/java/com/zoopick/server/service/notification/NotificationService.java
+++ b/src/main/java/com/zoopick/server/service/notification/NotificationService.java
@@ -65,8 +65,7 @@ public class NotificationService {
     }
 
     @Transactional
-    public String broadcast(SendNotificationCommand command) {
-        List<User> users = userRepository.findAll();
+    public String send(List<User> users, SendNotificationCommand command) {
         List<ZoopickNotification> zoopickNotifications = users.stream()
                 .map(user -> notificationMapper.toZoopickNotification(user, command))
                 .toList();
@@ -82,6 +81,12 @@ public class NotificationService {
                 .toList();
         eventPublisher.publishEvent(new NotificationDispatchRequestedEvent(messages));
         return String.valueOf(messages.size());
+    }
+
+    @Transactional
+    public String broadcast(SendNotificationCommand command) {
+        List<User> users = userRepository.findAll();
+        return send(users, command);
     }
 
     public void storeNotification(long userId, NotificationPayload payload) {
@@ -114,6 +119,7 @@ public class NotificationService {
         return findNotificationsWith(userId, notificationRepository::findByUserIdAndReadAtIsNullOrderByCreatedAtDesc);
     }
 
+    @Transactional
     public void markAllChatsAsRead(long userId, long roomId) {
         List<ZoopickNotification> notifications = notificationRepository.findAllByUserIdAndType(userId, NotificationType.CHAT_MESSAGE);
         for (ZoopickNotification notification : notifications) {

--- a/src/main/java/com/zoopick/server/service/notification/payload/ChatMessagePayload.java
+++ b/src/main/java/com/zoopick/server/service/notification/payload/ChatMessagePayload.java
@@ -5,28 +5,28 @@ import com.zoopick.server.entity.ChatRoom;
 import com.zoopick.server.entity.NotificationType;
 import com.zoopick.server.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.Map;
 
-@AllArgsConstructor
 @NullMarked
 @Schema(
         name = "ChatMessagePayload",
         description = "CHAT_MESSAGE : 채팅 메시지 알림 payload"
 )
-public class ChatMessagePayload implements NotificationPayload {
-    @JsonProperty("room_id")
-    @Schema(description = "채팅방 ID", example = "123")
-    private final long roomId;
-    @JsonProperty("sender_nickname")
-    @Schema(description = "보낸 사람 닉네임", example = "zoopickUser")
-    private final String senderNickname;
-    @JsonProperty("message")
-    @Schema(description = "메시지 내용", example = "물건 찾으셨나요?")
-    private final String message;
+public record ChatMessagePayload(
+        @JsonProperty("room_id")
+        @Schema(description = "채팅방 ID", example = "123")
+        long roomId,
 
+        @JsonProperty("sender_nickname")
+        @Schema(description = "보낸 사람 닉네임", example = "zoopickUser")
+        String senderNickname,
+
+        @JsonProperty("message")
+        @Schema(description = "메시지 내용", example = "물건 찾으셨나요?")
+        String message
+) implements NotificationPayload {
     public static ChatMessagePayload of(ChatRoom chatRoom, User sender, String message) {
         return new ChatMessagePayload(chatRoom.getId(), sender.getNickname(), message);
     }

--- a/src/main/java/com/zoopick/server/service/notification/payload/ItemReturnedPayload.java
+++ b/src/main/java/com/zoopick/server/service/notification/payload/ItemReturnedPayload.java
@@ -4,25 +4,24 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.zoopick.server.entity.ItemPost;
 import com.zoopick.server.entity.NotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.Map;
 
-@AllArgsConstructor
 @NullMarked
 @Schema(
         name = "ItemReturnedPayload",
         description = "ITEM_RETURNED : 분실물 반환 알림 payload"
 )
-public class ItemReturnedPayload implements NotificationPayload {
-    @JsonProperty("item_id")
-    @Schema(description = "물품 ID", example = "10")
-    private final long itemId;
-    @JsonProperty("item_post_id")
-    @Schema(description = "게시글 ID", example = "45")
-    private final long itemPostId;
+public record ItemReturnedPayload(
+        @JsonProperty("item_id")
+        @Schema(description = "물품 ID", example = "10")
+        long itemId,
 
+        @JsonProperty("item_post_id")
+        @Schema(description = "게시글 ID", example = "45")
+        long itemPostId
+) implements NotificationPayload {
     public static ItemReturnedPayload of(ItemPost itemPost) {
         return new ItemReturnedPayload(itemPost.getItem().getId(), itemPost.getId());
     }

--- a/src/main/java/com/zoopick/server/service/notification/payload/LockerReadyPayload.java
+++ b/src/main/java/com/zoopick/server/service/notification/payload/LockerReadyPayload.java
@@ -4,22 +4,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.zoopick.server.entity.Item;
 import com.zoopick.server.entity.NotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.Map;
 
-@AllArgsConstructor
 @NullMarked
 @Schema(
         name = "LockerReadyPayload",
         description = "LOCKER_READY : 락커 보관 완료 알림 payload"
 )
-public class LockerReadyPayload implements NotificationPayload {
-    @JsonProperty("item_id")
-    @Schema(description = "물품 ID", example = "10")
-    private final long itemId;
-
+public record LockerReadyPayload(
+        @JsonProperty("item_id")
+        @Schema(description = "물품 ID", example = "10")
+        long itemId
+) implements NotificationPayload {
     public static LockerReadyPayload of(Item item) {
         return new LockerReadyPayload(item.getId());
     }

--- a/src/main/java/com/zoopick/server/service/notification/payload/MatchFoundPayload.java
+++ b/src/main/java/com/zoopick/server/service/notification/payload/MatchFoundPayload.java
@@ -5,28 +5,28 @@ import com.zoopick.server.entity.Item;
 import com.zoopick.server.entity.ItemMatch;
 import com.zoopick.server.entity.NotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.Map;
 
-@AllArgsConstructor
 @NullMarked
 @Schema(
         name = "MatchFoundPayload",
         description = "MATCH_FOUND : 매칭 발견 알림 payload"
 )
-public class MatchFoundPayload implements NotificationPayload {
-    @JsonProperty("item_id")
-    @Schema(description = "분실물 ID", example = "10")
-    private final long itemId;
-    @JsonProperty("match_id")
-    @Schema(description = "매칭 ID", example = "55")
-    private final long matchId;
-    @JsonProperty("score")
-    @Schema(description = "매칭 점수", example = "0.87")
-    private final float score;
+public record MatchFoundPayload(
+        @JsonProperty("item_id")
+        @Schema(description = "분실물 ID", example = "10")
+        long itemId,
 
+        @JsonProperty("match_id")
+        @Schema(description = "매칭 ID", example = "55")
+        long matchId,
+
+        @JsonProperty("score")
+        @Schema(description = "매칭 점수", example = "0.87")
+        float score
+) implements NotificationPayload {
     public static MatchFoundPayload of(Item item, ItemMatch itemMatch) {
         return new MatchFoundPayload(item.getId(), itemMatch.getId(), itemMatch.getScore());
     }

--- a/src/main/java/com/zoopick/server/service/notification/payload/TheftSuspectedPayload.java
+++ b/src/main/java/com/zoopick/server/service/notification/payload/TheftSuspectedPayload.java
@@ -4,22 +4,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.zoopick.server.entity.Item;
 import com.zoopick.server.entity.NotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.Map;
 
-@AllArgsConstructor
 @NullMarked
 @Schema(
         name = "TheftSuspectedPayload",
         description = "THEFT_SUSPECTED : 도난 의심 알림 payload"
 )
-public class TheftSuspectedPayload implements NotificationPayload {
-    @JsonProperty("item_id")
-    @Schema(description = "물품 ID", example = "10")
-    private final long itemId;
-
+public record TheftSuspectedPayload(
+        @JsonProperty("item_id")
+        @Schema(description = "물품 ID", example = "10")
+        long itemId
+) implements NotificationPayload {
     public static TheftSuspectedPayload of(Item item) {
         return new TheftSuspectedPayload(item.getId());
     }

--- a/src/main/java/com/zoopick/server/websocket/ChatWebSocketBroadcaster.java
+++ b/src/main/java/com/zoopick/server/websocket/ChatWebSocketBroadcaster.java
@@ -2,7 +2,9 @@ package com.zoopick.server.websocket;
 
 import com.zoopick.server.service.ChatRoomService;
 import com.zoopick.server.websocket.message.ChatBroadcastPayload;
+import com.zoopick.server.websocket.message.ChatEventPayload;
 import com.zoopick.server.websocket.message.ChatInformationPayload;
+import com.zoopick.server.websocket.message.ChatReadPayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NullMarked;
@@ -30,7 +32,7 @@ public class ChatWebSocketBroadcaster {
      * @param senderSession 보내는 사람의 세션
      * @param message       메시지
      */
-    public void broadcast(long roomId, WebSocketSession senderSession, String message) {
+    public void broadcastChat(long roomId, WebSocketSession senderSession, String message) {
         long senderId = WebSocketSessionUtils.getUserId(senderSession);
         String senderNickname = WebSocketSessionUtils.getNickname(senderSession);
         ChatBroadcastPayload payload = new ChatBroadcastPayload(senderNickname, message);
@@ -43,12 +45,21 @@ public class ChatWebSocketBroadcaster {
                 .filter(participantId -> !receiverInWebSocketIds.contains(participantId))
                 .forEach(participantId -> chatRoomService.sendMessageWithNotification(senderId, roomId, message));
         receiverInWebSocketIds.forEach(receiverId -> chatRoomService.sendMessageWithoutNotification(senderId, roomId, message));
-
-        int sentByWebSocketCount = sessions.size() - receiverInWebSocketIds.size();
-        chatEventSender.sendMessageSafely(senderSession, new ChatInformationPayload(sentByWebSocketCount + "개의 세션으로 메시지가 전송되었습니다."));
+        chatEventSender.sendMessageSafely(senderSession, new ChatInformationPayload(receiverInWebSocketIds.size() + "개의 세션으로 메시지가 전송되었습니다."));
     }
 
-    private List<Long> sendMessageToOthers(WebSocketSession senderSession, Set<WebSocketSession> sessions, ChatBroadcastPayload payload) {
+    public void broadcastRead(long roomId, WebSocketSession senderSession) {
+        long senderId = WebSocketSessionUtils.getUserId(senderSession);
+        String senderNickname = WebSocketSessionUtils.getNickname(senderSession);
+        ChatReadPayload payload = new ChatReadPayload(senderNickname);
+        chatRoomService.readChatMessages(senderId, roomId);
+
+        Set<WebSocketSession> sessions = webSocketSessionManager.getSessionsByRoom(roomId);
+        List<Long> receiverInWebSocketIds = sendMessageToOthers(senderSession, sessions, payload);
+        chatEventSender.sendMessageSafely(senderSession, new ChatInformationPayload(receiverInWebSocketIds.size() + "개의 세션으로 읽음 상태가 전송되었습니다."));
+    }
+
+    private List<Long> sendMessageToOthers(WebSocketSession senderSession, Set<WebSocketSession> sessions, ChatEventPayload payload) {
         List<Long> receiverInWebSocketIds = new ArrayList<>();
 
         for (WebSocketSession session : sessions) {

--- a/src/main/java/com/zoopick/server/websocket/ChatWebSocketHandler.java
+++ b/src/main/java/com/zoopick/server/websocket/ChatWebSocketHandler.java
@@ -6,7 +6,7 @@ import com.zoopick.server.exception.DataNotFoundException;
 import com.zoopick.server.exception.InternalServerException;
 import com.zoopick.server.service.ChatRoomService;
 import com.zoopick.server.websocket.message.ChatErrorPayload;
-import com.zoopick.server.websocket.message.ChatMessageRequest;
+import com.zoopick.server.websocket.message.ChatRequestMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NullMarked;
@@ -45,14 +45,16 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) {
         try {
-            ChatMessageRequest request = objectMapper.readValue(message.getPayload(), ChatMessageRequest.class);
+            ChatRequestMessage request = objectMapper.readValue(message.getPayload(), ChatRequestMessage.class);
             if (!validateChatRoomAccess(session, request))
                 return;
 
             if (!webSocketSessionManager.getSessionsByRoom(request.roomId()).contains(session))
                 webSocketSessionManager.join(request.roomId(), session);
-            if (request.type() == ChatMessageRequest.Type.MESSAGE)
-                chatWebSocketBroadcaster.broadcast(request.roomId(), session, request.message());
+            if (request.type() == ChatRequestMessage.Type.MESSAGE)
+                chatWebSocketBroadcaster.broadcastChat(request.roomId(), session, request.message());
+            if (request.type() == ChatRequestMessage.Type.READ)
+                chatWebSocketBroadcaster.broadcastRead(request.roomId(), session);
         } catch (InternalServerException exception) {
             chatEventSender.sendErrorSafely(session, ChatErrorPayload.Reason.INTERNAL_SERVER_ERROR, exception.getClientMessage());
             log.error("Failed to handle websocket message. sessionId={}", session.getId(), exception);
@@ -67,7 +69,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         }
     }
 
-    private boolean validateChatRoomAccess(WebSocketSession session, ChatMessageRequest request) {
+    private boolean validateChatRoomAccess(WebSocketSession session, ChatRequestMessage request) {
         long userId = WebSocketSessionUtils.getUserId(session);
         if (!chatRoomService.getParticipants(request.roomId()).contains(userId)) {
             chatEventSender.sendErrorSafely(session, ChatErrorPayload.Reason.NOT_PERMITTED, "채팅방에 참여할 수 없습니다.");

--- a/src/main/java/com/zoopick/server/websocket/message/ChatEventMessage.java
+++ b/src/main/java/com/zoopick/server/websocket/message/ChatEventMessage.java
@@ -8,6 +8,7 @@ public record ChatEventMessage(Type type, ChatEventPayload payload) {
     public enum Type {
         INFO,
         ERROR,
-        MESSAGE
+        MESSAGE,
+        READ
     }
 }

--- a/src/main/java/com/zoopick/server/websocket/message/ChatReadPayload.java
+++ b/src/main/java/com/zoopick/server/websocket/message/ChatReadPayload.java
@@ -1,0 +1,12 @@
+package com.zoopick.server.websocket.message;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public record ChatReadPayload(@JsonProperty("reader_nickname") String readerNickname) implements ChatEventPayload {
+    @Override
+    public ChatEventMessage.Type type() {
+        return ChatEventMessage.Type.READ;
+    }
+}

--- a/src/main/java/com/zoopick/server/websocket/message/ChatRequestMessage.java
+++ b/src/main/java/com/zoopick/server/websocket/message/ChatRequestMessage.java
@@ -2,9 +2,10 @@ package com.zoopick.server.websocket.message;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record ChatMessageRequest(Type type, @JsonProperty("room_id") long roomId, String message) {
+public record ChatRequestMessage(Type type, @JsonProperty("room_id") long roomId, String message) {
     public enum Type {
         JOIN,
-        MESSAGE
+        MESSAGE,
+        READ
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,6 +41,7 @@ fastapi.cctv.read-timeout=3s
 zoopick.callback-url=${ZOOPICK_CALLBACK_URL:http://localhost:8080}
 zoopick.upload.image-dir=${ZOOPICK_UPLOAD_IMAGE_DIR:uploads/images}
 zoopick.cctv.snapshot-dir=${ZOOPICK_CCTV_SNAPSHOT_DIR:storage/cctv/snapshots}
+zoopick.base-url=${ZOOPICK_BASE_URL:http://localhost:8080}
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=20MB
 zoopick.similarity.threshold=${ZOOPICK_SIMILARITY_THRESHOLD:0.85}


### PR DESCRIPTION
### 클라이언트 → 서버

서버에 읽었음을 알립니다.
ChatMessage와 Notification 모두 읽은 시각을 기록합니다.

```json
{ "type": "READ", "room_id": 1 }
```

###  서버 → 클라이언트

다른 사용자에게 읽었음을 알립니다.

```json
{ "type": "READ", "payload": { "reader_nickname": "bontin" } }
```