### PR TITLE
사용자 Role, 채팅 메시지 조회 수정

### DIFF
--- a/src/main/java/com/zoopick/server/controller/NotificationController.java
+++ b/src/main/java/com/zoopick/server/controller/NotificationController.java
@@ -1,6 +1,5 @@
 package com.zoopick.server.controller;
 
-import com.google.firebase.messaging.FirebaseMessagingException;
 import com.zoopick.server.dto.CommonResponse;
 import com.zoopick.server.dto.notification.*;
 import com.zoopick.server.mapper.notification.SendNotificationRequestMapper;
@@ -53,7 +52,7 @@ public class NotificationController {
     public ResponseEntity<CommonResponse<String>> sendNotification(
             @PathVariable long userId,
             @RequestBody @Valid SendNotificationRequest request
-    ) throws FirebaseMessagingException {
+    ) {
         String result = notificationService.send(userId, sendNotificationRequestMapper.toCommand(request));
         return ResponseEntity.ok(CommonResponse.success(result));
     }
@@ -67,7 +66,7 @@ public class NotificationController {
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<CommonResponse<String>> broadcastNotification(
             @RequestBody @Valid SendNotificationRequest request
-    ) throws FirebaseMessagingException {
+    ) {
         String result = notificationService.broadcast(sendNotificationRequestMapper.toCommand(request));
         return ResponseEntity.ok(CommonResponse.success(result));
     }

--- a/src/main/java/com/zoopick/server/entity/Role.java
+++ b/src/main/java/com/zoopick/server/entity/Role.java
@@ -19,9 +19,9 @@ public enum Role {
 
     Role(Role... childRoles) {
         authorities = new HashSet<>();
-        authorities.add(new SimpleGrantedAuthority(PREFIX + getRoleName()));
+        authorities.add(new SimpleGrantedAuthority(getRoleName()));
         for (Role childRole : childRoles)
-            authorities.add(new SimpleGrantedAuthority(PREFIX + childRole.getRoleName()));
+            authorities.add(new SimpleGrantedAuthority(childRole.getRoleName()));
     }
 
     public String getRoleName() {

--- a/src/main/java/com/zoopick/server/repository/ChatMessageRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ChatMessageRepository.java
@@ -39,4 +39,6 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>,
     }
 
     List<ChatMessage> findByRoomAndSenderIsNot(@NotNull ChatRoom room, @NotNull User sender);
+
+    List<ChatMessage> findByRoomOrderBySentAt(@NotNull ChatRoom room, Specification<ChatMessage> chatMessageSpecification);
 }

--- a/src/main/java/com/zoopick/server/service/ChatRoomService.java
+++ b/src/main/java/com/zoopick/server/service/ChatRoomService.java
@@ -154,7 +154,7 @@ public class ChatRoomService {
         ChatRoom chatRoom = chatRoomRepository.findByIdOrThrow(chatRoomId);
         verifyParticipant(chatRoom, user);
 
-        List<ChatMessage> messages = chatMessageRepository.findAll(ChatMessageRepository.applyFilter(filter));
+        List<ChatMessage> messages = chatMessageRepository.findByRoomOrderBySentAt(chatRoom, ChatMessageRepository.applyFilter(filter));
         List<MessageRecord> messageRecords = messages.stream()
                 .map(chatMessageMapper::toMessageRecord)
                 .toList();


### PR DESCRIPTION
### 사용자 Role
- ROLE_ prefix가 2번 적용되고 있었음
- 1번만 적용되도록 수정

### 채팅 내역 조회
- 모든 채팅 내역을 조회하고 있었음
- 주어진 채팅방의 채팅 내용만 조회하도록 수정
- 날짜 순으로 정렬