### PR TITLE
웹소켓 채팅 전달 / FCM 알림 전달 방식 변경

### DIFF
--- a/src/main/java/com/zoopick/server/controller/ChatRoomController.java
+++ b/src/main/java/com/zoopick/server/controller/ChatRoomController.java
@@ -4,6 +4,7 @@ import com.zoopick.server.dto.CommonResponse;
 import com.zoopick.server.dto.chat.*;
 import com.zoopick.server.security.UserPrincipal;
 import com.zoopick.server.service.ChatRoomService;
+import com.zoopick.server.websocket.ChatWebSocketBroadcaster;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -23,9 +24,11 @@ import org.springframework.web.bind.annotation.*;
 @NullMarked
 public class ChatRoomController {
     private final ChatRoomService chatRoomService;
+    private final ChatWebSocketBroadcaster chatWebSocketBroadcaster;
 
-    public ChatRoomController(ChatRoomService chatRoomService) {
+    public ChatRoomController(ChatRoomService chatRoomService, ChatWebSocketBroadcaster chatWebSocketBroadcaster) {
         this.chatRoomService = chatRoomService;
+        this.chatWebSocketBroadcaster = chatWebSocketBroadcaster;
     }
 
     @Operation(summary = "채팅방 목록 조회", description = "현재 로그인한 사용자가 참여 중인 채팅방 ID 목록을 조회합니다.")
@@ -141,7 +144,7 @@ public class ChatRoomController {
             @PathVariable long roomId,
             @RequestBody @Valid SendMessageRequest sendMessageRequest
     ) {
-        chatRoomService.sendMessageWithNotification(principal.id(), roomId, sendMessageRequest.getMessage());
+        chatWebSocketBroadcaster.broadcastChat(roomId, principal.id(), principal.nickname(), sendMessageRequest.getMessage());
         return ResponseEntity.ok(CommonResponse.success("done"));
     }
 

--- a/src/main/java/com/zoopick/server/controller/NotificationController.java
+++ b/src/main/java/com/zoopick/server/controller/NotificationController.java
@@ -1,6 +1,5 @@
 package com.zoopick.server.controller;
 
-import com.google.firebase.messaging.FirebaseMessagingException;
 import com.zoopick.server.dto.CommonResponse;
 import com.zoopick.server.dto.notification.*;
 import com.zoopick.server.mapper.notification.SendNotificationRequestMapper;
@@ -53,7 +52,7 @@ public class NotificationController {
     public ResponseEntity<CommonResponse<String>> sendNotification(
             @PathVariable long userId,
             @RequestBody @Valid SendNotificationRequest request
-    ) throws FirebaseMessagingException {
+    ) {
         String result = notificationService.send(userId, sendNotificationRequestMapper.toCommand(request));
         return ResponseEntity.ok(CommonResponse.success(result));
     }
@@ -67,7 +66,7 @@ public class NotificationController {
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<CommonResponse<String>> broadcastNotification(
             @RequestBody @Valid SendNotificationRequest request
-    ) throws FirebaseMessagingException {
+    ) {
         String result = notificationService.broadcast(sendNotificationRequestMapper.toCommand(request));
         return ResponseEntity.ok(CommonResponse.success(result));
     }

--- a/src/main/java/com/zoopick/server/entity/Role.java
+++ b/src/main/java/com/zoopick/server/entity/Role.java
@@ -19,9 +19,9 @@ public enum Role {
 
     Role(Role... childRoles) {
         authorities = new HashSet<>();
-        authorities.add(new SimpleGrantedAuthority(PREFIX + getRoleName()));
+        authorities.add(new SimpleGrantedAuthority(getRoleName()));
         for (Role childRole : childRoles)
-            authorities.add(new SimpleGrantedAuthority(PREFIX + childRole.getRoleName()));
+            authorities.add(new SimpleGrantedAuthority(childRole.getRoleName()));
     }
 
     public String getRoleName() {

--- a/src/main/java/com/zoopick/server/repository/ChatMessageRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ChatMessageRepository.java
@@ -39,4 +39,6 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>,
     }
 
     List<ChatMessage> findByRoomAndSenderIsNot(@NotNull ChatRoom room, @NotNull User sender);
+
+    List<ChatMessage> findByRoomOrderBySentAt(@NotNull ChatRoom room, Specification<ChatMessage> chatMessageSpecification);
 }

--- a/src/main/java/com/zoopick/server/service/ChatRoomService.java
+++ b/src/main/java/com/zoopick/server/service/ChatRoomService.java
@@ -154,7 +154,7 @@ public class ChatRoomService {
         ChatRoom chatRoom = chatRoomRepository.findByIdOrThrow(chatRoomId);
         verifyParticipant(chatRoom, user);
 
-        List<ChatMessage> messages = chatMessageRepository.findAll(ChatMessageRepository.applyFilter(filter));
+        List<ChatMessage> messages = chatMessageRepository.findByRoomOrderBySentAt(chatRoom, ChatMessageRepository.applyFilter(filter));
         List<MessageRecord> messageRecords = messages.stream()
                 .map(chatMessageMapper::toMessageRecord)
                 .toList();

--- a/src/main/java/com/zoopick/server/service/notification/NotificationDispatchEventListener.java
+++ b/src/main/java/com/zoopick/server/service/notification/NotificationDispatchEventListener.java
@@ -3,7 +3,6 @@ package com.zoopick.server.service.notification;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
 import com.zoopick.server.exception.DataNotFoundException;
 import com.zoopick.server.service.notification.event.FcmMessageRequest;
 import com.zoopick.server.service.notification.event.NotificationDispatchRequestedEvent;
@@ -35,12 +34,7 @@ public class NotificationDispatchEventListener {
     }
 
     private Message toMessage(FcmMessageRequest request) {
-        Notification notification = Notification.builder()
-                .setTitle(request.title())
-                .setBody(request.body())
-                .build();
         return Message.builder()
-                .setNotification(notification)
                 .putAllData(request.data())
                 .setToken(request.token().orElseThrow(() -> DataNotFoundException.from("FCM 토큰", request)))
                 .build();

--- a/src/main/java/com/zoopick/server/service/notification/NotificationService.java
+++ b/src/main/java/com/zoopick/server/service/notification/NotificationService.java
@@ -181,6 +181,8 @@ public class NotificationService {
         Map<String, String> data = new HashMap<>(command.payload().toMap());
         data.put("type", command.payload().type().name());
         data.put("id", String.valueOf(notification.getId()));
-        return new FcmMessageRequest(Optional.ofNullable(fcmToken), command.title(), command.body(), data);
+        data.put("title", command.title());
+        data.put("body", command.body());
+        return new FcmMessageRequest(Optional.ofNullable(fcmToken), data);
     }
 }

--- a/src/main/java/com/zoopick/server/service/notification/event/FcmMessageRequest.java
+++ b/src/main/java/com/zoopick/server/service/notification/event/FcmMessageRequest.java
@@ -8,8 +8,6 @@ import java.util.Optional;
 @NullMarked
 public record FcmMessageRequest(
         Optional<String> token,
-        String title,
-        String body,
         Map<String, String> data
 ) {
     public boolean hasToken() {

--- a/src/main/java/com/zoopick/server/websocket/ChatWebSocketBroadcaster.java
+++ b/src/main/java/com/zoopick/server/websocket/ChatWebSocketBroadcaster.java
@@ -8,6 +8,7 @@ import com.zoopick.server.websocket.message.ChatReadPayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketSession;
 
@@ -27,10 +28,13 @@ public class ChatWebSocketBroadcaster {
     /**
      * 채팅방의 다른 사용자들에게 메시지를 전송합니다.
      * 웹소켓를 통한 메시지 전송에 실패한 경우 FCM을 통해 알림을 보냅니다.
+     * 보내는 사람에게 전송 상태를 알립니다.
      *
      * @param roomId        채팅방 Id
      * @param senderSession 보내는 사람의 세션
      * @param message       메시지
+     *
+     * @see #broadcastChat(long, long, String, String) 
      */
     public void broadcastChat(long roomId, WebSocketSession senderSession, String message) {
         long senderId = WebSocketSessionUtils.getUserId(senderSession);
@@ -48,6 +52,29 @@ public class ChatWebSocketBroadcaster {
         chatEventSender.sendMessageSafely(senderSession, new ChatInformationPayload(receiverInWebSocketIds.size() + "개의 세션으로 메시지가 전송되었습니다."));
     }
 
+    /**
+     * 채팅방의 다른 사용자들에게 메시지를 전송합니다.
+     * 웹소켓를 통한 메시지 전송에 실패한 경우 FCM을 통해 알림을 보냅니다.
+     *
+     * @param roomId         채팅방 Id
+     * @param senderId       보내는 사람 Id
+     * @param senderNickname 보내는 사람
+     * @param message        메시지
+     * @see #broadcastChat(long, WebSocketSession, String)
+     */
+    public void broadcastChat(long roomId, long senderId, String senderNickname, String message) {
+        ChatBroadcastPayload payload = new ChatBroadcastPayload(senderNickname, message);
+
+        Set<WebSocketSession> sessions = webSocketSessionManager.getSessionsByRoom(roomId);
+        List<Long> receiverInWebSocketIds = sendMessageToOthers(null, sessions, payload);
+
+        chatRoomService.getParticipants(roomId).stream()
+                .filter(participantId -> participantId != senderId)
+                .filter(participantId -> !receiverInWebSocketIds.contains(participantId))
+                .forEach(participantId -> chatRoomService.sendMessageWithNotification(senderId, roomId, message));
+        receiverInWebSocketIds.forEach(receiverId -> chatRoomService.sendMessageWithoutNotification(senderId, roomId, message));
+    }
+
     public void broadcastRead(long roomId, WebSocketSession senderSession) {
         long senderId = WebSocketSessionUtils.getUserId(senderSession);
         String senderNickname = WebSocketSessionUtils.getNickname(senderSession);
@@ -59,11 +86,11 @@ public class ChatWebSocketBroadcaster {
         chatEventSender.sendMessageSafely(senderSession, new ChatInformationPayload(receiverInWebSocketIds.size() + "개의 세션으로 읽음 상태가 전송되었습니다."));
     }
 
-    private List<Long> sendMessageToOthers(WebSocketSession senderSession, Set<WebSocketSession> sessions, ChatEventPayload payload) {
+    private List<Long> sendMessageToOthers(@Nullable WebSocketSession senderSession, Set<WebSocketSession> sessions, ChatEventPayload payload) {
         List<Long> receiverInWebSocketIds = new ArrayList<>();
 
         for (WebSocketSession session : sessions) {
-            if (!session.isOpen() || session.getId().equals(senderSession.getId()))
+            if (!session.isOpen() || (senderSession != null && session.getId().equals(senderSession.getId())))
                 continue;
 
             long id = WebSocketSessionUtils.getUserId(session);


### PR DESCRIPTION
- /api/chat-rooms/{roomId}/messages/send 를 통해 전송 시 웹소켓에는 전달되지 않고 있었음
- 웹소켓의 사용자는 웹소켓을 통해 채팅 전달
- 앱에서 알림이 자동 생성되지 않도록 하기 위해 Notification을 사용하는 대신 Message의 data영역에 title, body를 포함
