### PR TITLE
feat: CCTV-분실물 AI 매칭 기능 구현 및 매칭 리뷰 API 추가

### DIFF
--- a/src/main/java/com/zoopick/server/config/MatchConfig.java
+++ b/src/main/java/com/zoopick/server/config/MatchConfig.java
@@ -1,0 +1,15 @@
+package com.zoopick.server.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "zoopick.match")
+@Getter
+@Setter
+public class MatchConfig {
+    private float similarityThreshold; // 코사인 유사도 임계값
+    private float colorBonus; // 색깔 같으면 가산점
+}

--- a/src/main/java/com/zoopick/server/config/SecurityConfig.java
+++ b/src/main/java/com/zoopick/server/config/SecurityConfig.java
@@ -36,12 +36,11 @@ public class SecurityConfig {
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                 .requestMatchers("/", "/Login", "/join").permitAll()
                 .requestMatchers(HttpMethod.GET, "/images/**").permitAll()
-                .requestMatchers("/**").permitAll()
+
                 // Vision 및 CCTV API 허용 (테스트용)
                 .requestMatchers("/api/vision/**", "/api/cctv/**", "/api/internal/**").permitAll()
                 .requestMatchers("/cctv-admin.html").permitAll()
                 .requestMatchers("/storage/**").permitAll()
-                .requestMatchers("/api/cctv/upload").permitAll()
 
                 // IoT 디바이스(아두이노) 전용 엔드포인트 허용
                 .requestMatchers(HttpMethod.GET, "/api/lockers/*/pending").permitAll()

--- a/src/main/java/com/zoopick/server/config/SecurityConfig.java
+++ b/src/main/java/com/zoopick/server/config/SecurityConfig.java
@@ -36,12 +36,13 @@ public class SecurityConfig {
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                 .requestMatchers("/", "/Login", "/join").permitAll()
                 .requestMatchers(HttpMethod.GET, "/images/**").permitAll()
-
+                .requestMatchers("/**").permitAll()
                 // Vision 및 CCTV API 허용 (테스트용)
                 .requestMatchers("/api/vision/**", "/api/cctv/**", "/api/internal/**").permitAll()
                 .requestMatchers("/cctv-admin.html").permitAll()
                 .requestMatchers("/storage/**").permitAll()
                 .requestMatchers("/api/cctv/upload").permitAll()
+
                 // IoT 디바이스(아두이노) 전용 엔드포인트 허용
                 .requestMatchers(HttpMethod.GET, "/api/lockers/*/pending").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/lockers/*/commands/*/ack").permitAll()

--- a/src/main/java/com/zoopick/server/controller/CctvController.java
+++ b/src/main/java/com/zoopick/server/controller/CctvController.java
@@ -2,6 +2,7 @@ package com.zoopick.server.controller;
 
 import com.zoopick.server.dto.CommonResponse;
 import com.zoopick.server.dto.cctv.*;
+import com.zoopick.server.dto.cctv.GetDetectionByItemIdResponse;
 import com.zoopick.server.security.UserPrincipal;
 import com.zoopick.server.service.CctvService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -113,25 +114,32 @@ public class CctvController {
     }
 
     @Operation(
-            summary = "나의 CCTV 분실물 매칭 목록 조회",
+            summary = "나의 CCTV 매칭 현황 및 상세 조회",
             description = """
-        로그인한 유저가 등록한 분실물 중 CCTV AI 분석을 통해 매칭된 결과 목록을 조회합니다.
-        매칭 횟수가 1회 이상인 아이템만 반환됩니다.
+        유저가 등록한 분실물들과 CCTV AI 분석으로 매칭된 결과들을 조회합니다.
+        
+        1. 일반 호출: CCTV 매칭 이력이 있는 나의 '분실물 목록'을 조회합니다.
+        2. itemId 호출: 특정 분실물에 대해 매칭된 'CCTV 상세 탐지 정보(시간, 장소, 스코어 등)' 목록을 조회합니다.
         """
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자 (토큰 만료 또는 없음)"),
-            @ApiResponse(responseCode = "404", description = "유저 정보를 찾을 수 없음")
+            @ApiResponse(responseCode = "404", description = "유저 또는 해당 아이템 정보를 찾을 수 없음")
     })
     @GetMapping("/detections/me")
-    public ResponseEntity<CommonResponse<GetDetectionsMeResponse>> getDetectionsMe(
+    public ResponseEntity<CommonResponse<?>> getDetectionsMe(
             @Parameter(description = "조회할 유저")
-            @AuthenticationPrincipal UserPrincipal principal) {
-        GetDetectionsMeResponse response = cctvService.getDetectionsMe(1L);
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam(value = "itemId", required = false) Long itemId) {
+        if (itemId == null) {
+            GetDetectionsMeResponse response = cctvService.getDetectionsMe(principal.id());
+            return ResponseEntity.ok(CommonResponse.success(response));
+        }
+
+        GetDetectionByItemIdResponse response = cctvService.getDetectionsMeByItemId(principal.id(), itemId);
         return ResponseEntity.ok(CommonResponse.success(response));
     }
-
 
     @Operation(
             summary = "CCTV 업로드",

--- a/src/main/java/com/zoopick/server/controller/CctvController.java
+++ b/src/main/java/com/zoopick/server/controller/CctvController.java
@@ -142,6 +142,32 @@ public class CctvController {
     }
 
     @Operation(
+            summary = "CCTV 매칭 결과 검토(확정/거절)",
+            description = """
+        사용자가 본인의 분실물과 매칭된 CCTV 탐지 결과를 검토하고 상태를 업데이트합니다.
+        
+        상태 값:
+        - CONFIRMED_SELF: 내 물건이 맞음 (도난 의심)
+        - REJECTED_SELF: 내 물건이 아님 (도난 아님)
+        """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "검토 결과 반영 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "해당 탐지 결과에 대한 접근 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "탐지 정보를 찾을 수 없음")
+    })
+    @PutMapping("/detections/{detectionId}/review")
+    public ResponseEntity<CommonResponse<?>> reviewMatch(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Parameter(description = "검토할 탐지 결과 ID") @PathVariable Long detectionId,
+            @Valid @RequestBody CctvDetectionReviewRequest request
+    ) {
+        cctvService.reviewMatch(userPrincipal.id(), detectionId, request);
+        return ResponseEntity.ok(CommonResponse.success(null));
+    }
+
+    @Operation(
             summary = "CCTV 업로드",
             description = """
             관리자가 CCTV를 업로드합니다.

--- a/src/main/java/com/zoopick/server/controller/CctvController.java
+++ b/src/main/java/com/zoopick/server/controller/CctvController.java
@@ -157,13 +157,13 @@ public class CctvController {
             @ApiResponse(responseCode = "403", description = "해당 탐지 결과에 대한 접근 권한 없음"),
             @ApiResponse(responseCode = "404", description = "탐지 정보를 찾을 수 없음")
     })
-    @PutMapping("/detections/{detectionId}/review")
+    @PutMapping("/detections/{matchId}/review")
     public ResponseEntity<CommonResponse<?>> reviewMatch(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @Parameter(description = "검토할 탐지 결과 ID") @PathVariable Long detectionId,
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Parameter(description = "리뷰할 매칭 ID") @PathVariable Long matchId,
             @Valid @RequestBody CctvDetectionReviewRequest request
     ) {
-        cctvService.reviewMatch(userPrincipal.id(), detectionId, request);
+        cctvService.reviewMatch(principal.id(), matchId, request);
         return ResponseEntity.ok(CommonResponse.success(null));
     }
 

--- a/src/main/java/com/zoopick/server/controller/CctvController.java
+++ b/src/main/java/com/zoopick/server/controller/CctvController.java
@@ -2,14 +2,17 @@ package com.zoopick.server.controller;
 
 import com.zoopick.server.dto.CommonResponse;
 import com.zoopick.server.dto.cctv.*;
+import com.zoopick.server.security.UserPrincipal;
 import com.zoopick.server.service.CctvService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -109,6 +112,36 @@ public class CctvController {
         return ResponseEntity.ok(CommonResponse.success(response));
     }
 
+    @Operation(
+            summary = "나의 CCTV 분실물 매칭 목록 조회",
+            description = """
+        로그인한 유저가 등록한 분실물 중 CCTV AI 분석을 통해 매칭된 결과 목록을 조회합니다.
+        매칭 횟수가 1회 이상인 아이템만 반환됩니다.
+        """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자 (토큰 만료 또는 없음)"),
+            @ApiResponse(responseCode = "404", description = "유저 정보를 찾을 수 없음")
+    })
+    @GetMapping("/detections/me")
+    public ResponseEntity<CommonResponse<GetDetectionsMeResponse>> getDetectionsMe(
+            @Parameter(description = "조회할 유저")
+            @AuthenticationPrincipal UserPrincipal principal) {
+        GetDetectionsMeResponse response = cctvService.getDetectionsMe(1L);
+        return ResponseEntity.ok(CommonResponse.success(response));
+    }
+
+
+    @Operation(
+            summary = "CCTV 업로드",
+            description = """
+            관리자가 CCTV를 업로드합니다.
+            """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/upload")
     public ResponseEntity<CommonResponse<String>> uploadVideo(@RequestParam("file") MultipartFile file) throws IOException {
         String path = cctvService.uploadVideo(file);

--- a/src/main/java/com/zoopick/server/dto/cctv/CctvDetectionDetail.java
+++ b/src/main/java/com/zoopick/server/dto/cctv/CctvDetectionDetail.java
@@ -12,8 +12,8 @@ import java.time.LocalDateTime;
 @Setter
 @AllArgsConstructor
 public class CctvDetectionDetail {
-    @JsonProperty("detection_id")
-    private Long detectionId;
+    @JsonProperty("match_id")
+    private Long matchId;
 
     private double score;
 

--- a/src/main/java/com/zoopick/server/dto/cctv/CctvDetectionDetail.java
+++ b/src/main/java/com/zoopick/server/dto/cctv/CctvDetectionDetail.java
@@ -1,0 +1,35 @@
+package com.zoopick.server.dto.cctv;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class CctvDetectionDetail {
+    @JsonProperty("detection_id")
+    private Long detectionId;
+
+    private double score;
+
+    @JsonProperty("detected_at")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    LocalDateTime detectedAt;
+
+    @JsonProperty("building_name")
+    private String buildingName;
+
+    @JsonProperty("room_name")
+    private String roomName;
+
+    @JsonProperty("item_snapshot_url")
+    private String itemSnapshotUrl;
+
+    @JsonProperty("moment_snapshot_url")
+    private String momentSnapshotUrl;
+}

--- a/src/main/java/com/zoopick/server/dto/cctv/CctvDetectionReviewRequest.java
+++ b/src/main/java/com/zoopick/server/dto/cctv/CctvDetectionReviewRequest.java
@@ -1,0 +1,17 @@
+package com.zoopick.server.dto.cctv;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.zoopick.server.entity.DetectionReviewStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class CctvDetectionReviewRequest {
+    @NotNull
+    @JsonProperty("review_status")
+    DetectionReviewStatus reviewStatus;
+}

--- a/src/main/java/com/zoopick/server/dto/cctv/GetAllDetectionResponse.java
+++ b/src/main/java/com/zoopick/server/dto/cctv/GetAllDetectionResponse.java
@@ -1,7 +1,6 @@
 package com.zoopick.server.dto.cctv;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.zoopick.server.entity.DetectionReviewStatus;
 import com.zoopick.server.entity.ItemCategory;
 import com.zoopick.server.entity.ItemColor;
 import lombok.AllArgsConstructor;
@@ -23,6 +22,4 @@ public class GetAllDetectionResponse {
     private ItemCategory detectedCategory;
     @JsonProperty("detected_color")
     private ItemColor detectedColor;
-    @JsonProperty("review_status")
-    private DetectionReviewStatus reviewStatus;
 }

--- a/src/main/java/com/zoopick/server/dto/cctv/GetDetectionByIdResponse.java
+++ b/src/main/java/com/zoopick/server/dto/cctv/GetDetectionByIdResponse.java
@@ -2,7 +2,6 @@ package com.zoopick.server.dto.cctv;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.zoopick.server.entity.DetectionReviewStatus;
 import com.zoopick.server.entity.ItemCategory;
 import com.zoopick.server.entity.ItemColor;
 import lombok.AllArgsConstructor;
@@ -30,10 +29,6 @@ public class GetDetectionByIdResponse {
     private String itemSnapshotUrl;
     @JsonProperty("moment_snapshot_url")
     private String momentSnapshotUrl;
-    @JsonProperty("review_status")
-    private DetectionReviewStatus reviewStatus = DetectionReviewStatus.PENDING;
-    @JsonProperty("reviewed_at")
-    private LocalDateTime reviewedAt;
     @JsonProperty("created_at")
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/zoopick/server/dto/cctv/GetDetectionByItemIdResponse.java
+++ b/src/main/java/com/zoopick/server/dto/cctv/GetDetectionByItemIdResponse.java
@@ -1,0 +1,14 @@
+package com.zoopick.server.dto.cctv;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class GetDetectionByItemIdResponse {
+    List<CctvDetectionDetail> detections;
+}

--- a/src/main/java/com/zoopick/server/dto/cctv/GetDetectionsMeResponse.java
+++ b/src/main/java/com/zoopick/server/dto/cctv/GetDetectionsMeResponse.java
@@ -1,0 +1,17 @@
+package com.zoopick.server.dto.cctv;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetDetectionsMeResponse {
+
+    @JsonProperty("matched_lost_items")
+    private List<MatchedLostItems> matchedLostItems;
+}

--- a/src/main/java/com/zoopick/server/dto/cctv/MatchedLostItems.java
+++ b/src/main/java/com/zoopick/server/dto/cctv/MatchedLostItems.java
@@ -1,0 +1,32 @@
+package com.zoopick.server.dto.cctv;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.zoopick.server.entity.ItemCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchedLostItems {
+    @JsonProperty("lost_item_id")
+    long lostItemId;
+
+    String title;
+
+    ItemCategory category;
+
+    @JsonProperty("match_count")
+    int matchCount;
+
+    @JsonProperty("reported_at")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    LocalDateTime reportedAt;
+
+    @JsonProperty("image_url")
+    String imageUrl;
+}

--- a/src/main/java/com/zoopick/server/dto/item/ItemCreatedEvent.java
+++ b/src/main/java/com/zoopick/server/dto/item/ItemCreatedEvent.java
@@ -1,4 +1,6 @@
 package com.zoopick.server.dto.item;
 
-public record ItemCreatedEvent(Long itemId) {
+import com.zoopick.server.entity.ItemType;
+
+public record ItemCreatedEvent(Long itemId, ItemType itemType) {
 }

--- a/src/main/java/com/zoopick/server/dto/match/CctvMatchCriteria.java
+++ b/src/main/java/com/zoopick/server/dto/match/CctvMatchCriteria.java
@@ -1,0 +1,9 @@
+package com.zoopick.server.dto.match;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CctvMatchCriteria(
+        List<Long> roomIds,
+        LocalDateTime searchStartTime
+) {}

--- a/src/main/java/com/zoopick/server/dto/match/CreateCctvMatchEvent.java
+++ b/src/main/java/com/zoopick/server/dto/match/CreateCctvMatchEvent.java
@@ -3,7 +3,7 @@ package com.zoopick.server.dto.match;
 import com.zoopick.server.entity.CctvDetection;
 import com.zoopick.server.entity.CctvDetectionMatch;
 import com.zoopick.server.entity.Item;
+import com.zoopick.server.entity.ItemPost;
 
-public record CreateCctvMatchEvent(Item item, CctvDetectionMatch cctvDetectionMatch, CctvDetection cctvDetection,
-                                   com.zoopick.server.entity.ItemPost itemPost) {
+public record CreateCctvMatchEvent(Item item, CctvDetectionMatch cctvDetectionMatch, CctvDetection cctvDetection, ItemPost itemPost) {
 }

--- a/src/main/java/com/zoopick/server/dto/match/CreateCctvMatchEvent.java
+++ b/src/main/java/com/zoopick/server/dto/match/CreateCctvMatchEvent.java
@@ -1,0 +1,9 @@
+package com.zoopick.server.dto.match;
+
+import com.zoopick.server.entity.CctvDetection;
+import com.zoopick.server.entity.CctvDetectionMatch;
+import com.zoopick.server.entity.Item;
+
+public record CreateCctvMatchEvent(Item item, CctvDetectionMatch cctvDetectionMatch, CctvDetection cctvDetection,
+                                   com.zoopick.server.entity.ItemPost itemPost) {
+}

--- a/src/main/java/com/zoopick/server/dto/match/CreateMatchEvent.java
+++ b/src/main/java/com/zoopick/server/dto/match/CreateMatchEvent.java
@@ -1,3 +1,6 @@
 package com.zoopick.server.dto.match;
 
-public record CreateMatchEvent(Long matchId, Long lostItemId, Long foundItemId) {}
+import com.zoopick.server.entity.Item;
+import com.zoopick.server.entity.ItemMatch;
+
+public record CreateMatchEvent(ItemMatch match, Item lostItem, Item foundItem) {}

--- a/src/main/java/com/zoopick/server/dto/match/SaveCctvDetectionEvent.java
+++ b/src/main/java/com/zoopick/server/dto/match/SaveCctvDetectionEvent.java
@@ -1,0 +1,4 @@
+package com.zoopick.server.dto.match;
+
+public record SaveCctvDetectionEvent(Long detectionId) {
+}

--- a/src/main/java/com/zoopick/server/entity/CctvDetection.java
+++ b/src/main/java/com/zoopick/server/entity/CctvDetection.java
@@ -64,4 +64,9 @@ public class CctvDetection {
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreatedDate
     private LocalDateTime createdAt;
+
+    public void updateDetectionReviewStatus(DetectionReviewStatus reviewStatus) {
+        this.reviewStatus = reviewStatus;
+        this.reviewedAt = LocalDateTime.now(); // 리뷰 시점 기록
+    }
 }

--- a/src/main/java/com/zoopick/server/entity/CctvDetection.java
+++ b/src/main/java/com/zoopick/server/entity/CctvDetection.java
@@ -52,21 +52,7 @@ public class CctvDetection {
     @Column(name = "moment_snapshot_url", length = 500)
     private String momentSnapshotUrl;
 
-    @Enumerated(EnumType.STRING)
-    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
-    @Column(name = "review_status", columnDefinition = "detection_review_status")
-    @Builder.Default
-    private DetectionReviewStatus reviewStatus = DetectionReviewStatus.PENDING;
-
-    @Column(name = "reviewed_at")
-    private LocalDateTime reviewedAt;
-
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreatedDate
     private LocalDateTime createdAt;
-
-    public void updateDetectionReviewStatus(DetectionReviewStatus reviewStatus) {
-        this.reviewStatus = reviewStatus;
-        this.reviewedAt = LocalDateTime.now(); // 리뷰 시점 기록
-    }
 }

--- a/src/main/java/com/zoopick/server/entity/CctvDetectionMatch.java
+++ b/src/main/java/com/zoopick/server/entity/CctvDetectionMatch.java
@@ -4,6 +4,10 @@ package com.zoopick.server.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "cctv_detection_matches", schema = "zoopick")
@@ -28,10 +32,24 @@ public class CctvDetectionMatch {
     @NotNull
     private float score;
 
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "review_status", columnDefinition = "detection_review_status")
+    @Builder.Default
+    private DetectionReviewStatus reviewStatus = DetectionReviewStatus.PENDING;
+
+    @Column(name = "reviewed_at")
+    private LocalDateTime reviewedAt;
+
     @PrePersist
     @PreUpdate
     public void formatScore() {
         // 저장 및 수정 직전에 0.85714...를 0.857로 변환
         this.score = Math.round(this.score * 1000f) / 1000f;
+    }
+
+    public void updateDetectionReviewStatus(DetectionReviewStatus reviewStatus) {
+        this.reviewStatus = reviewStatus;
+        this.reviewedAt = LocalDateTime.now(); // 리뷰 시점 기록
     }
 }

--- a/src/main/java/com/zoopick/server/entity/CctvDetectionMatch.java
+++ b/src/main/java/com/zoopick/server/entity/CctvDetectionMatch.java
@@ -1,0 +1,37 @@
+package com.zoopick.server.entity;
+
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Entity
+@Table(name = "cctv_detection_matches", schema = "zoopick")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CctvDetectionMatch {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "detection_id", nullable = false)
+    private CctvDetection cctvDetection;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @NotNull
+    private float score;
+
+    @PrePersist
+    @PreUpdate
+    public void formatScore() {
+        // 저장 및 수정 직전에 0.85714...를 0.857로 변환
+        this.score = Math.round(this.score * 1000f) / 1000f;
+    }
+}

--- a/src/main/java/com/zoopick/server/entity/Item.java
+++ b/src/main/java/com/zoopick/server/entity/Item.java
@@ -80,4 +80,8 @@ public class Item {
     @Column(name = "updated_at")
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    public void theftSuspected(LocalDateTime suspectedAt) {
+        this.theftSuspectedAt = suspectedAt;
+    }
 }

--- a/src/main/java/com/zoopick/server/entity/NotificationType.java
+++ b/src/main/java/com/zoopick/server/entity/NotificationType.java
@@ -2,6 +2,7 @@ package com.zoopick.server.entity;
 
 public enum NotificationType {
     MATCH_FOUND,
+    CCTV_FOUND,
     CHAT_MESSAGE,
     ITEM_RETURNED,
     THEFT_SUSPECTED,

--- a/src/main/java/com/zoopick/server/mapper/notification/NotificationPayloadMapper.java
+++ b/src/main/java/com/zoopick/server/mapper/notification/NotificationPayloadMapper.java
@@ -20,7 +20,8 @@ public class NotificationPayloadMapper {
             NotificationType.ITEM_RETURNED, ItemReturnedPayload.class,
             NotificationType.LOCKER_READY, LockerReadyPayload.class,
             NotificationType.THEFT_SUSPECTED, TheftSuspectedPayload.class,
-            NotificationType.MATCH_FOUND, MatchFoundPayload.class
+            NotificationType.MATCH_FOUND, MatchFoundPayload.class,
+            NotificationType.CCTV_FOUND, CctvFoundPayload.class
     );
 
     private final ObjectMapper objectMapper;

--- a/src/main/java/com/zoopick/server/repository/CctvDetectionMatchRepository.java
+++ b/src/main/java/com/zoopick/server/repository/CctvDetectionMatchRepository.java
@@ -1,6 +1,5 @@
 package com.zoopick.server.repository;
 
-import com.zoopick.server.dto.cctv.MatchedLostItems;
 import com.zoopick.server.dto.match.SimilarItemProjection;
 import com.zoopick.server.entity.CctvDetection;
 import com.zoopick.server.entity.CctvDetectionMatch;
@@ -65,21 +64,7 @@ public interface CctvDetectionMatchRepository extends JpaRepository<CctvDetectio
     // 중복 체크
     boolean existsByCctvDetectionAndItem(CctvDetection detection, Item lostItem);
 
+    boolean existsByCctvDetectionIdAndItemReporterId(Long detectionId, Long itemReporterId);
 
-    @Query("""
-         SELECT new com.zoopick.server.dto.cctv.MatchedLostItems(
-              i.id,
-              p.title,
-              i.category,
-              CAST(COUNT(m.id) AS int),
-              i.reportedAt,
-              i.imageUrl
-         )
-         FROM ItemPost p
-         JOIN p.item i
-         JOIN CctvDetectionMatch m ON m.item.id = i.id
-         WHERE p.user.id = :userId
-         GROUP BY i.id, p.title, i.category, i.reportedAt, i.imageUrl
-     """)
-    List<MatchedLostItems> findCctvDetectionByUserId(@Param("userId") Long userId);
+    CctvDetectionMatch findByCctvDetectionIdAndItemReporterId(Long detectionId, Long itemReporterId);
 }

--- a/src/main/java/com/zoopick/server/repository/CctvDetectionMatchRepository.java
+++ b/src/main/java/com/zoopick/server/repository/CctvDetectionMatchRepository.java
@@ -3,9 +3,11 @@ package com.zoopick.server.repository;
 import com.zoopick.server.dto.match.SimilarItemProjection;
 import com.zoopick.server.entity.CctvDetection;
 import com.zoopick.server.entity.CctvDetectionMatch;
+import com.zoopick.server.entity.DetectionReviewStatus;
 import com.zoopick.server.entity.Item;
 import org.springframework.data.domain.Vector;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -64,7 +66,20 @@ public interface CctvDetectionMatchRepository extends JpaRepository<CctvDetectio
     // 중복 체크
     boolean existsByCctvDetectionAndItem(CctvDetection detection, Item lostItem);
 
-    boolean existsByCctvDetectionIdAndItemReporterId(Long detectionId, Long itemReporterId);
-
-    CctvDetectionMatch findByCctvDetectionIdAndItemReporterId(Long detectionId, Long itemReporterId);
+    @Modifying
+    @Query("""
+    UPDATE CctvDetectionMatch m 
+    SET m.reviewStatus = :rejectedStatus,
+        m.reviewedAt = :now
+    WHERE m.item.id = :itemId 
+      AND m.id != :confirmedMatchId 
+      AND m.reviewStatus = :pendingStatus
+""")
+    void rejectOtherPendingMatches(
+            @Param("itemId") Long itemId,
+            @Param("confirmedMatchId") Long confirmedMatchId,
+            @Param("rejectedStatus") DetectionReviewStatus rejectedStatus,
+            @Param("pendingStatus") DetectionReviewStatus pendingStatus,
+            @Param("now") LocalDateTime now
+    );
 }

--- a/src/main/java/com/zoopick/server/repository/CctvDetectionMatchRepository.java
+++ b/src/main/java/com/zoopick/server/repository/CctvDetectionMatchRepository.java
@@ -67,20 +67,19 @@ public interface CctvDetectionMatchRepository extends JpaRepository<CctvDetectio
 
 
     @Query("""
-     SELECT new com.zoopick.server.dto.cctv.MatchedLostItems(
-          i.id,
-          p.title,
-          i.category,
-          CAST(COUNT(m.id) AS int),
-          i.reportedAt,
-          i.imageUrl
-          )
-     FROM ItemPost p
-     JOIN p.item i
-     LEFT JOIN CctvDetectionMatch m ON m.item.id = i.id
-     WHERE p.user.id = :userId
-     GROUP BY i.id, p.title, i.category, i.reportedAt, i.imageUrl
-     HAVING COUNT(m.id) > 0
+         SELECT new com.zoopick.server.dto.cctv.MatchedLostItems(
+              i.id,
+              p.title,
+              i.category,
+              CAST(COUNT(m.id) AS int),
+              i.reportedAt,
+              i.imageUrl
+         )
+         FROM ItemPost p
+         JOIN p.item i
+         JOIN CctvDetectionMatch m ON m.item.id = i.id
+         WHERE p.user.id = :userId
+         GROUP BY i.id, p.title, i.category, i.reportedAt, i.imageUrl
      """)
     List<MatchedLostItems> findCctvDetectionByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/zoopick/server/repository/CctvDetectionMatchRepository.java
+++ b/src/main/java/com/zoopick/server/repository/CctvDetectionMatchRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -24,7 +25,9 @@ public interface CctvDetectionMatchRepository extends JpaRepository<CctvDetectio
         FROM zoopick.items i
         WHERE i.type = CAST('LOST' AS item_type)
           AND i.returned_at IS NULL
+          AND i.theft_suspected_at IS NULL
           AND i.category = CAST(:category AS item_category)
+          AND i.reported_at <= (CAST(:detectionTime AS timestamp) + interval '6 hours')
         ORDER BY i.embedding <=> CAST(:embedding AS vector)
         LIMIT 100
     ) t
@@ -33,6 +36,7 @@ public interface CctvDetectionMatchRepository extends JpaRepository<CctvDetectio
     """, nativeQuery = true)
     List<SimilarItemProjection> findLostItems(@Param("embedding") Vector embedding,
                                                  @Param("category") String category,
+                                                 @Param("detectionTime") LocalDateTime detectionTime,
                                                  @Param("threshold") float threshold);
 
     @Query(value = """
@@ -42,7 +46,10 @@ public interface CctvDetectionMatchRepository extends JpaRepository<CctvDetectio
             d.id AS itemId,
             1 - (d.embedding <=> CAST(:embedding AS vector)) AS score
         FROM zoopick.cctv_detections d
+        JOIN zoopick.cctv_videos v ON d.video_id = v.id
         WHERE d.detected_category = CAST(:category AS item_category)
+          AND v.room_id IN (:roomIds)
+          AND v.recorded_at >= :lostTime
         ORDER BY d.embedding <=> CAST(:embedding AS vector)
         LIMIT 100
     ) t
@@ -51,6 +58,8 @@ public interface CctvDetectionMatchRepository extends JpaRepository<CctvDetectio
     """, nativeQuery = true)
     List<SimilarItemProjection> findDetections(@Param("embedding") Vector embedding,
                                               @Param("category") String category,
+                                              @Param("roomIds") List<Long> roomIds,
+                                              @Param("lostTime") LocalDateTime lostTime,
                                               @Param("threshold") float threshold);
 
     // 중복 체크

--- a/src/main/java/com/zoopick/server/repository/CctvDetectionMatchRepository.java
+++ b/src/main/java/com/zoopick/server/repository/CctvDetectionMatchRepository.java
@@ -1,5 +1,6 @@
 package com.zoopick.server.repository;
 
+import com.zoopick.server.dto.cctv.MatchedLostItems;
 import com.zoopick.server.dto.match.SimilarItemProjection;
 import com.zoopick.server.entity.CctvDetection;
 import com.zoopick.server.entity.CctvDetectionMatch;
@@ -54,4 +55,23 @@ public interface CctvDetectionMatchRepository extends JpaRepository<CctvDetectio
 
     // 중복 체크
     boolean existsByCctvDetectionAndItem(CctvDetection detection, Item lostItem);
+
+
+    @Query("""
+     SELECT new com.zoopick.server.dto.cctv.MatchedLostItems(
+          i.id,
+          p.title,
+          i.category,
+          CAST(COUNT(m.id) AS int),
+          i.reportedAt,
+          i.imageUrl
+          )
+     FROM ItemPost p
+     JOIN p.item i
+     LEFT JOIN CctvDetectionMatch m ON m.item.id = i.id
+     WHERE p.user.id = :userId
+     GROUP BY i.id, p.title, i.category, i.reportedAt, i.imageUrl
+     HAVING COUNT(m.id) > 0
+     """)
+    List<MatchedLostItems> findCctvDetectionByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/zoopick/server/repository/CctvDetectionMatchRepository.java
+++ b/src/main/java/com/zoopick/server/repository/CctvDetectionMatchRepository.java
@@ -1,0 +1,57 @@
+package com.zoopick.server.repository;
+
+import com.zoopick.server.dto.match.SimilarItemProjection;
+import com.zoopick.server.entity.CctvDetection;
+import com.zoopick.server.entity.CctvDetectionMatch;
+import com.zoopick.server.entity.Item;
+import org.springframework.data.domain.Vector;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CctvDetectionMatchRepository extends JpaRepository<CctvDetectionMatch, Long> {
+    @Query(value = """
+    SELECT *
+    FROM (
+        SELECT
+            i.id AS itemId,
+            1 - (i.embedding <=> CAST(:embedding AS vector)) AS score
+        FROM zoopick.items i
+        WHERE i.type = CAST('LOST' AS item_type)
+          AND i.returned_at IS NULL
+          AND i.category = CAST(:category AS item_category)
+        ORDER BY i.embedding <=> CAST(:embedding AS vector)
+        LIMIT 100
+    ) t
+    WHERE t.score >= :threshold
+        LIMIT 30
+    """, nativeQuery = true)
+    List<SimilarItemProjection> findLostItems(@Param("embedding") Vector embedding,
+                                                 @Param("category") String category,
+                                                 @Param("threshold") float threshold);
+
+    @Query(value = """
+    SELECT *
+    FROM (
+        SELECT
+            d.id AS itemId,
+            1 - (d.embedding <=> CAST(:embedding AS vector)) AS score
+        FROM zoopick.cctv_detections d
+        WHERE d.detected_category = CAST(:category AS item_category)
+        ORDER BY d.embedding <=> CAST(:embedding AS vector)
+        LIMIT 100
+    ) t
+    WHERE t.score >= :threshold
+        LIMIT 30
+    """, nativeQuery = true)
+    List<SimilarItemProjection> findDetections(@Param("embedding") Vector embedding,
+                                              @Param("category") String category,
+                                              @Param("threshold") float threshold);
+
+    // 중복 체크
+    boolean existsByCctvDetectionAndItem(CctvDetection detection, Item lostItem);
+}

--- a/src/main/java/com/zoopick/server/repository/CctvDetectionRepository.java
+++ b/src/main/java/com/zoopick/server/repository/CctvDetectionRepository.java
@@ -1,7 +1,9 @@
 package com.zoopick.server.repository;
 
+import com.zoopick.server.dto.cctv.CctvDetectionDetail;
 import com.zoopick.server.entity.CctvDetection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,4 +11,25 @@ import java.util.List;
 @Repository
 public interface CctvDetectionRepository extends JpaRepository<CctvDetection, Long> {
     List<CctvDetection> findAllByOrderByDetectedAtAsc();
+
+    @Query("""
+     SELECT new com.zoopick.server.dto.cctv.CctvDetectionDetail(
+         d.id,
+         m.score,
+         d.detectedAt,
+         b.name,
+         r.name,
+         d.itemSnapshotUrl,
+         d.momentSnapshotUrl
+     )
+     FROM CctvDetectionMatch m
+     JOIN m.item i
+     JOIN m.cctvDetection d
+     JOIN d.cctvVideo v
+     JOIN v.room r
+     JOIN r.building b
+     WHERE i.id = :itemId
+       AND i.reporter.id = :userId
+""")
+    List<CctvDetectionDetail> findCctvDetectionDetail(Long userId, Long itemId);
 }

--- a/src/main/java/com/zoopick/server/repository/CctvDetectionRepository.java
+++ b/src/main/java/com/zoopick/server/repository/CctvDetectionRepository.java
@@ -1,9 +1,11 @@
 package com.zoopick.server.repository;
 
 import com.zoopick.server.dto.cctv.CctvDetectionDetail;
+import com.zoopick.server.dto.cctv.MatchedLostItems;
 import com.zoopick.server.entity.CctvDetection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -30,6 +32,24 @@ public interface CctvDetectionRepository extends JpaRepository<CctvDetection, Lo
      JOIN r.building b
      WHERE i.id = :itemId
        AND i.reporter.id = :userId
+       AND d.reviewStatus = com.zoopick.server.entity.DetectionReviewStatus.PENDING
 """)
     List<CctvDetectionDetail> findCctvDetectionDetail(Long userId, Long itemId);
+
+    @Query("""
+     SELECT new com.zoopick.server.dto.cctv.MatchedLostItems(
+          i.id,
+          p.title,
+          i.category,
+          CAST(COUNT(m.id) AS int),
+          i.reportedAt,
+          i.imageUrl
+     )
+     FROM ItemPost p
+     JOIN p.item i
+     JOIN CctvDetectionMatch m ON m.item.id = i.id
+     WHERE p.user.id = :userId
+     GROUP BY i.id, p.title, i.category, i.reportedAt, i.imageUrl
+     """)
+    List<MatchedLostItems> findCctvDetectionByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/zoopick/server/repository/CctvDetectionRepository.java
+++ b/src/main/java/com/zoopick/server/repository/CctvDetectionRepository.java
@@ -3,6 +3,7 @@ package com.zoopick.server.repository;
 import com.zoopick.server.dto.cctv.CctvDetectionDetail;
 import com.zoopick.server.dto.cctv.MatchedLostItems;
 import com.zoopick.server.entity.CctvDetection;
+import com.zoopick.server.entity.DetectionReviewStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,7 +17,7 @@ public interface CctvDetectionRepository extends JpaRepository<CctvDetection, Lo
 
     @Query("""
      SELECT new com.zoopick.server.dto.cctv.CctvDetectionDetail(
-         d.id,
+         m.id,
          m.score,
          d.detectedAt,
          b.name,
@@ -32,9 +33,9 @@ public interface CctvDetectionRepository extends JpaRepository<CctvDetection, Lo
      JOIN r.building b
      WHERE i.id = :itemId
        AND i.reporter.id = :userId
-       AND d.reviewStatus = com.zoopick.server.entity.DetectionReviewStatus.PENDING
+       AND m.reviewStatus = :status
 """)
-    List<CctvDetectionDetail> findCctvDetectionDetail(Long userId, Long itemId);
+    List<CctvDetectionDetail> findCctvDetectionDetail(@Param("userId") Long userId, @Param("itemId") Long itemId, @Param("status") DetectionReviewStatus status);
 
     @Query("""
      SELECT new com.zoopick.server.dto.cctv.MatchedLostItems(
@@ -49,7 +50,8 @@ public interface CctvDetectionRepository extends JpaRepository<CctvDetection, Lo
      JOIN p.item i
      JOIN CctvDetectionMatch m ON m.item.id = i.id
      WHERE p.user.id = :userId
+       AND m.reviewStatus = :status
      GROUP BY i.id, p.title, i.category, i.reportedAt, i.imageUrl
      """)
-    List<MatchedLostItems> findCctvDetectionByUserId(@Param("userId") Long userId);
+    List<MatchedLostItems> findCctvDetectionByUserId(@Param("userId") Long userId, @Param("status") DetectionReviewStatus status);
 }

--- a/src/main/java/com/zoopick/server/repository/ItemPostRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ItemPostRepository.java
@@ -7,7 +7,11 @@ import jakarta.persistence.criteria.Join;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ItemPostRepository extends JpaRepository<ItemPost, Long>, JpaSpecificationExecutor<ItemPost> {
@@ -52,4 +56,7 @@ public interface ItemPostRepository extends JpaRepository<ItemPost, Long>, JpaSp
 
     long countByUserId(Long userId);
     ItemPost findByItem(Item item);
+
+    @Query("SELECT ip FROM ItemPost ip JOIN FETCH ip.item WHERE ip.item.id IN :itemIds")
+    List<ItemPost> findAllByItemIdsWithItem(@Param("itemIds") List<Long> itemIds);
 }

--- a/src/main/java/com/zoopick/server/repository/RoomRepository.java
+++ b/src/main/java/com/zoopick/server/repository/RoomRepository.java
@@ -1,13 +1,21 @@
 package com.zoopick.server.repository;
 
+import com.zoopick.server.entity.Building;
 import com.zoopick.server.entity.Room;
 import com.zoopick.server.exception.DataNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RoomRepository extends JpaRepository<Room, Long> {
     default Room findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(() -> DataNotFoundException.from("공간", id));
     }
+
+    Optional<Room> findByNameAndBuilding(String name, Building building);
+
+    List<Room> findAllByBuilding(Building building);
 }

--- a/src/main/java/com/zoopick/server/service/CctvMatchCriteriaResolver.java
+++ b/src/main/java/com/zoopick/server/service/CctvMatchCriteriaResolver.java
@@ -1,0 +1,72 @@
+package com.zoopick.server.service;
+
+import com.zoopick.server.dto.match.CctvMatchCriteria;
+import com.zoopick.server.entity.*;
+import com.zoopick.server.repository.CourseScheduleRepository;
+import com.zoopick.server.repository.RoomRepository;
+import com.zoopick.server.repository.TimetableGroupRepository;
+import com.zoopick.server.repository.TimetableRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CctvMatchCriteriaResolver {
+    private final TimetableGroupRepository timetableGroupRepository;
+    private final TimetableRepository timetableRepository;
+    private final CourseScheduleRepository courseScheduleRepository;
+    private final RoomRepository roomRepository;
+
+    public CctvMatchCriteria resolve(Item lostItem) {
+        if (lostItem.getReportedBuilding() == null) {
+            return new CctvMatchCriteria(List.of(),
+                    lostItem.getReportedAt() != null ? lostItem.getReportedAt() : LocalDateTime.now());
+        }
+
+        LocalDateTime reportedTime = lostItem.getReportedAt() != null ? lostItem.getReportedAt() : LocalDateTime.now();
+        DayOfWeek targetDay = DayOfWeek.valueOf(reportedTime.getDayOfWeek().name().substring(0, 3));
+        LocalTime targetLocalTime = reportedTime.toLocalTime();
+
+        boolean hasTimetableMatch = false;
+        LocalDateTime searchStartTime = reportedTime;
+        var primaryGroup = timetableGroupRepository.findByUserAndIsPrimaryTrue(lostItem.getReporter());
+
+        if (primaryGroup.isPresent()) {
+            List<Timetable> timetables = timetableRepository.findAllByTimetableGroup(primaryGroup.get());
+            List<Course> buildingCourses = timetables.stream()
+                    .map(Timetable::getCourse)
+                    .filter(c -> c.getRoom().getBuilding().getId().equals(lostItem.getReportedBuilding().getId()))
+                    .toList();
+
+            if (!buildingCourses.isEmpty()) {
+                List<CourseSchedule> schedules = courseScheduleRepository.findAllByCourseIn(buildingCourses);
+                var matchedSchedule = schedules.stream()
+                        .filter(s -> s.getDayOfWeek() == targetDay &&
+                                !targetLocalTime.isBefore(s.getStartTime()) &&
+                                !targetLocalTime.isAfter(s.getEndTime()))
+                        .findFirst();
+
+                if (matchedSchedule.isPresent()) {
+                    hasTimetableMatch = true;
+                    searchStartTime = LocalDateTime.of(reportedTime.toLocalDate(), matchedSchedule.get().getStartTime());
+                }
+            }
+        }
+
+        var reportedRoom = roomRepository.findByNameAndBuilding(lostItem.getLocationName(), lostItem.getReportedBuilding());
+
+        if (reportedRoom.isPresent() && hasTimetableMatch) {
+            return new CctvMatchCriteria(List.of(reportedRoom.get().getId()), searchStartTime);
+        } else {
+            List<Long> allRoomIds = roomRepository.findAllByBuilding(lostItem.getReportedBuilding())
+                    .stream()
+                    .map(Room::getId)
+                    .toList();
+            return new CctvMatchCriteria(allRoomIds, reportedTime);
+        }
+    }
+}

--- a/src/main/java/com/zoopick/server/service/CctvMatchService.java
+++ b/src/main/java/com/zoopick/server/service/CctvMatchService.java
@@ -159,6 +159,6 @@ public class CctvMatchService {
         if (itemColor == detectionColor) {
             finalScore *= matchConfig.getColorBonus();
         }
-        return finalScore;
+        return Math.min(finalScore, 1.0f);
     }
 }

--- a/src/main/java/com/zoopick/server/service/CctvMatchService.java
+++ b/src/main/java/com/zoopick/server/service/CctvMatchService.java
@@ -1,15 +1,19 @@
 package com.zoopick.server.service;
 
+import com.zoopick.server.dto.match.CreateCctvMatchEvent;
 import com.zoopick.server.dto.match.SimilarItemResult;
 import com.zoopick.server.entity.CctvDetection;
 import com.zoopick.server.entity.CctvDetectionMatch;
 import com.zoopick.server.entity.Item;
+import com.zoopick.server.entity.ItemPost;
 import com.zoopick.server.repository.CctvDetectionMatchRepository;
 import com.zoopick.server.repository.CctvDetectionRepository;
+import com.zoopick.server.repository.ItemPostRepository;
 import com.zoopick.server.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Vector;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -26,6 +30,8 @@ public class CctvMatchService {
     private final CctvDetectionRepository cctvDetectionRepository;
     private final CctvDetectionMatchRepository cctvDetectionMatchRepository;
     private final ItemRepository itemRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final ItemPostRepository itemPostRepository;
     @Value("${zoopick.similarity.threshold}")
     private float similarityThreshold;
 
@@ -46,14 +52,21 @@ public class CctvMatchService {
             log.warn("[CCTV] 매칭된 아이템이 없습니다.");
             return;
         }
-        Map<Long, Item> itemMap = itemRepository.findAllById(
-                        similarItems.stream().map(SimilarItemResult::getItemId).toList())
+        List<Long> itemIds = similarItems.stream()
+                .map(SimilarItemResult::getItemId)
+                .toList();
+
+        Map<Long, ItemPost> itemPostMap = itemPostRepository.findAllByItemIdsWithItem(itemIds)
                 .stream()
-                .collect(Collectors.toMap(Item::getId, i -> i));
+                .collect(Collectors.toMap(
+                        post -> post.getItem().getId(), // Key: Item의 ID
+                        post -> post                   // Value: ItemPost 객체 (안에 Item이 들어있음)
+                ));
 
         for (SimilarItemResult s : similarItems) {
             // 중복 저장 방지
-            Item foundItemInDb = itemMap.get(s.getItemId());
+            ItemPost itemPost = itemPostMap.get(s.getItemId());
+            Item foundItemInDb = itemPost.getItem();
             if (!cctvDetectionMatchRepository.existsByCctvDetectionAndItem(cctvDetection, foundItemInDb)) {
                 CctvDetectionMatch savedMatch = cctvDetectionMatchRepository.save(CctvDetectionMatch.builder()
                         .score((float) s.getScore())
@@ -62,6 +75,7 @@ public class CctvMatchService {
                         .build());
                 log.info("CCTV 매칭된 아이템 ID: {}", foundItemInDb.getId());
                 //TODO: 이벤트 퍼블리싱으로 FCM 보내기
+                eventPublisher.publishEvent(new CreateCctvMatchEvent(foundItemInDb, savedMatch, cctvDetection, itemPost));
             }
         }
         log.info("[CCTV] 매칭 종료 ID: {}", detectionId);
@@ -71,6 +85,8 @@ public class CctvMatchService {
     public void matchLostItemsToCctv(Long lostItemId) {
         log.info("[CCTV] 매칭 시작 ID: {}", lostItemId);
         Item lostItem = itemRepository.findByIdOrThrow(lostItemId);
+        ItemPost lostItemPost = itemPostRepository.findByItem(lostItem);
+
         Vector embedding = Vector.of(lostItem.getEmbedding());
         List<SimilarItemResult> similarItems = cctvDetectionMatchRepository.findDetections(
                         embedding,
@@ -104,6 +120,7 @@ public class CctvMatchService {
                         .build());
                 log.info("[CCTV] 매칭된 Detection ID: {}", foundItemInDb.getId());
                 //TODO: 이벤트 퍼블리싱으로 FCM 보내기
+                eventPublisher.publishEvent(new CreateCctvMatchEvent(lostItem, savedMatch, foundItemInDb, lostItemPost));
             }
         }
         log.info("[CCTV] 매칭 종료 ID: {}", lostItemId);

--- a/src/main/java/com/zoopick/server/service/CctvMatchService.java
+++ b/src/main/java/com/zoopick/server/service/CctvMatchService.java
@@ -1,13 +1,16 @@
 package com.zoopick.server.service;
 
+import com.zoopick.server.config.MatchConfig;
 import com.zoopick.server.dto.match.CctvMatchCriteria;
 import com.zoopick.server.dto.match.CreateCctvMatchEvent;
 import com.zoopick.server.dto.match.SimilarItemResult;
 import com.zoopick.server.entity.*;
-import com.zoopick.server.repository.*;
+import com.zoopick.server.repository.CctvDetectionMatchRepository;
+import com.zoopick.server.repository.CctvDetectionRepository;
+import com.zoopick.server.repository.ItemPostRepository;
+import com.zoopick.server.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Vector;
 import org.springframework.stereotype.Service;
@@ -22,6 +25,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Slf4j
 public class CctvMatchService {
+    private final MatchConfig matchConfig;
     private final CctvDetectionRepository cctvDetectionRepository;
     private final CctvDetectionMatchRepository cctvDetectionMatchRepository;
     private final ItemRepository itemRepository;
@@ -29,9 +33,7 @@ public class CctvMatchService {
     private final ItemPostRepository itemPostRepository;
     private final CctvMatchCriteriaResolver cctvMatchCriteriaResolver;
 
-    @Value("${zoopick.similarity.threshold}")
-    private float similarityThreshold;
-
+    //CCTV가 분석 완료됐을 때 매칭
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void matchCctvToLostItems(Long detectionId) {
         log.info("[CCTV] 매칭 시작 ID: {}", detectionId);
@@ -45,7 +47,7 @@ public class CctvMatchService {
                 embedding,
                 cctvDetection.getDetectedCategory().name(),
                 cctvDetection.getCctvVideo().getRecordedAt(),
-                similarityThreshold)
+                matchConfig.getSimilarityThreshold())
                 .stream()
                 .map(p -> new SimilarItemResult(p.getItemId(), p.getScore()))
                 .toList();
@@ -84,8 +86,9 @@ public class CctvMatchService {
             }
 
             if (!cctvDetectionMatchRepository.existsByCctvDetectionAndItem(cctvDetection, lostItem)) {
+                float finalScore = calculateBonusScore(s.getScore(), lostItem.getColor(), cctvDetection.getDetectedColor());
                 CctvDetectionMatch savedMatch = cctvDetectionMatchRepository.save(CctvDetectionMatch.builder()
-                        .score((float) s.getScore())
+                        .score(finalScore)
                         .item(lostItem)
                         .cctvDetection(cctvDetection)
                         .build());
@@ -96,6 +99,7 @@ public class CctvMatchService {
         log.info("[CCTV] 매칭 종료 ID: {}", detectionId);
     }
 
+    //사용자가 글을 올렸을 때 매칭
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void matchLostItemsToCctv(Long lostItemId) {
         log.info("[CCTV] 매칭 시작 ID: {}", lostItemId);
@@ -115,7 +119,7 @@ public class CctvMatchService {
                 lostItem.getCategory().name(),
                 criteria.roomIds(),
                 criteria.searchStartTime(),
-                similarityThreshold)
+                matchConfig.getSimilarityThreshold())
                 .stream()
                 .map(p -> new SimilarItemResult(p.getItemId(), p.getScore()))
                 .toList();
@@ -135,8 +139,9 @@ public class CctvMatchService {
                 continue;
 
             if (!cctvDetectionMatchRepository.existsByCctvDetectionAndItem(foundItemInDb, lostItem)) {
+                float finalScore = calculateBonusScore(s.getScore(), lostItem.getColor(), foundItemInDb.getDetectedColor());
                 CctvDetectionMatch savedMatch = cctvDetectionMatchRepository.save(CctvDetectionMatch.builder()
-                        .score((float) s.getScore())
+                        .score(finalScore)
                         .item(lostItem)
                         .cctvDetection(foundItemInDb)
                         .build());
@@ -146,5 +151,14 @@ public class CctvMatchService {
             }
         }
         log.info("[CCTV] 매칭 종료 ID: {}", lostItemId);
+    }
+
+    private float calculateBonusScore(double baseScore, ItemColor itemColor, ItemColor detectionColor) {
+        float finalScore = (float) baseScore;
+        // 두 컬러가 모두 존재하고 일치할 경우 가산점 적용
+        if (itemColor == detectionColor) {
+            finalScore *= matchConfig.getColorBonus();
+        }
+        return finalScore;
     }
 }

--- a/src/main/java/com/zoopick/server/service/CctvMatchService.java
+++ b/src/main/java/com/zoopick/server/service/CctvMatchService.java
@@ -1,15 +1,10 @@
 package com.zoopick.server.service;
 
+import com.zoopick.server.dto.match.CctvMatchCriteria;
 import com.zoopick.server.dto.match.CreateCctvMatchEvent;
 import com.zoopick.server.dto.match.SimilarItemResult;
-import com.zoopick.server.entity.CctvDetection;
-import com.zoopick.server.entity.CctvDetectionMatch;
-import com.zoopick.server.entity.Item;
-import com.zoopick.server.entity.ItemPost;
-import com.zoopick.server.repository.CctvDetectionMatchRepository;
-import com.zoopick.server.repository.CctvDetectionRepository;
-import com.zoopick.server.repository.ItemPostRepository;
-import com.zoopick.server.repository.ItemRepository;
+import com.zoopick.server.entity.*;
+import com.zoopick.server.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -32,6 +27,8 @@ public class CctvMatchService {
     private final ItemRepository itemRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final ItemPostRepository itemPostRepository;
+    private final CctvMatchCriteriaResolver cctvMatchCriteriaResolver;
+
     @Value("${zoopick.similarity.threshold}")
     private float similarityThreshold;
 
@@ -39,11 +36,16 @@ public class CctvMatchService {
     public void matchCctvToLostItems(Long detectionId) {
         log.info("[CCTV] 매칭 시작 ID: {}", detectionId);
         CctvDetection cctvDetection = cctvDetectionRepository.findById(detectionId).orElse(null);
+        if (cctvDetection == null)
+            return;
+
         Vector embedding = Vector.of(cctvDetection.getEmbedding());
+
         List<SimilarItemResult> similarItems = cctvDetectionMatchRepository.findLostItems(
-                        embedding,
-                        cctvDetection.getDetectedCategory().name(),
-                        similarityThreshold)
+                embedding,
+                cctvDetection.getDetectedCategory().name(),
+                cctvDetection.getCctvVideo().getRecordedAt(),
+                similarityThreshold)
                 .stream()
                 .map(p -> new SimilarItemResult(p.getItemId(), p.getScore()))
                 .toList();
@@ -59,23 +61,36 @@ public class CctvMatchService {
         Map<Long, ItemPost> itemPostMap = itemPostRepository.findAllByItemIdsWithItem(itemIds)
                 .stream()
                 .collect(Collectors.toMap(
-                        post -> post.getItem().getId(), // Key: Item의 ID
-                        post -> post                   // Value: ItemPost 객체 (안에 Item이 들어있음)
-                ));
+                        post -> post.getItem().getId(),
+                        post -> post));
+
+        Room detectionRoom = cctvDetection.getCctvVideo().getRoom();
 
         for (SimilarItemResult s : similarItems) {
-            // 중복 저장 방지
             ItemPost itemPost = itemPostMap.get(s.getItemId());
-            Item foundItemInDb = itemPost.getItem();
-            if (!cctvDetectionMatchRepository.existsByCctvDetectionAndItem(cctvDetection, foundItemInDb)) {
+            if (itemPost == null)
+                continue;
+            Item lostItem = itemPost.getItem();
+
+            CctvMatchCriteria criteria = cctvMatchCriteriaResolver.resolve(lostItem);
+            if (!criteria.roomIds().contains(detectionRoom.getId())) {
+                log.debug("[CCTV] 아이템 검색 범위 외 강의실 탐지 ID: {}", lostItem.getId());
+                continue;
+            }
+
+            if (cctvDetection.getDetectedAt().isBefore(criteria.searchStartTime())) {
+                log.debug("[CCTV] 아이템 검색 시작 시간 이전 탐지 ID: {}", lostItem.getId());
+                continue;
+            }
+
+            if (!cctvDetectionMatchRepository.existsByCctvDetectionAndItem(cctvDetection, lostItem)) {
                 CctvDetectionMatch savedMatch = cctvDetectionMatchRepository.save(CctvDetectionMatch.builder()
                         .score((float) s.getScore())
-                        .item(foundItemInDb)
+                        .item(lostItem)
                         .cctvDetection(cctvDetection)
                         .build());
-                log.info("CCTV 매칭된 아이템 ID: {}", foundItemInDb.getId());
-                //TODO: 이벤트 퍼블리싱으로 FCM 보내기
-                eventPublisher.publishEvent(new CreateCctvMatchEvent(foundItemInDb, savedMatch, cctvDetection, itemPost));
+                log.info("CCTV 매칭된 아이템 ID: {}", lostItem.getId());
+                eventPublisher.publishEvent(new CreateCctvMatchEvent(lostItem, savedMatch, cctvDetection, itemPost));
             }
         }
         log.info("[CCTV] 매칭 종료 ID: {}", detectionId);
@@ -88,10 +103,19 @@ public class CctvMatchService {
         ItemPost lostItemPost = itemPostRepository.findByItem(lostItem);
 
         Vector embedding = Vector.of(lostItem.getEmbedding());
+
+        CctvMatchCriteria criteria = cctvMatchCriteriaResolver.resolve(lostItem);
+        if (criteria.roomIds().isEmpty()) {
+            log.info("[CCTV] 매칭 가능한 장소 정보가 없습니다. ID: {}", lostItemId);
+            return;
+        }
+
         List<SimilarItemResult> similarItems = cctvDetectionMatchRepository.findDetections(
-                        embedding,
-                        lostItem.getCategory().name(),
-                        similarityThreshold)
+                embedding,
+                lostItem.getCategory().name(),
+                criteria.roomIds(),
+                criteria.searchStartTime(),
+                similarityThreshold)
                 .stream()
                 .map(p -> new SimilarItemResult(p.getItemId(), p.getScore()))
                 .toList();
@@ -101,17 +125,15 @@ public class CctvMatchService {
             return;
         }
         Map<Long, CctvDetection> detectionMap = cctvDetectionRepository.findAllById(
-                        similarItems.stream().map(SimilarItemResult::getItemId).toList())
+                similarItems.stream().map(SimilarItemResult::getItemId).toList())
                 .stream()
                 .collect(Collectors.toMap(CctvDetection::getId, i -> i));
 
         for (SimilarItemResult s : similarItems) {
-            // 중복 저장 방지
             CctvDetection foundItemInDb = detectionMap.get(s.getItemId());
-            if (foundItemInDb == null) {
-                log.error("검색 결과에는 있으나 DB 조회에 실패한 Detection ID: {}", s.getItemId());
+            if (foundItemInDb == null)
                 continue;
-            }
+
             if (!cctvDetectionMatchRepository.existsByCctvDetectionAndItem(foundItemInDb, lostItem)) {
                 CctvDetectionMatch savedMatch = cctvDetectionMatchRepository.save(CctvDetectionMatch.builder()
                         .score((float) s.getScore())
@@ -119,8 +141,8 @@ public class CctvMatchService {
                         .cctvDetection(foundItemInDb)
                         .build());
                 log.info("[CCTV] 매칭된 Detection ID: {}", foundItemInDb.getId());
-                //TODO: 이벤트 퍼블리싱으로 FCM 보내기
-                eventPublisher.publishEvent(new CreateCctvMatchEvent(lostItem, savedMatch, foundItemInDb, lostItemPost));
+                eventPublisher
+                        .publishEvent(new CreateCctvMatchEvent(lostItem, savedMatch, foundItemInDb, lostItemPost));
             }
         }
         log.info("[CCTV] 매칭 종료 ID: {}", lostItemId);

--- a/src/main/java/com/zoopick/server/service/CctvMatchService.java
+++ b/src/main/java/com/zoopick/server/service/CctvMatchService.java
@@ -1,0 +1,111 @@
+package com.zoopick.server.service;
+
+import com.zoopick.server.dto.match.SimilarItemResult;
+import com.zoopick.server.entity.CctvDetection;
+import com.zoopick.server.entity.CctvDetectionMatch;
+import com.zoopick.server.entity.Item;
+import com.zoopick.server.repository.CctvDetectionMatchRepository;
+import com.zoopick.server.repository.CctvDetectionRepository;
+import com.zoopick.server.repository.ItemRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Vector;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CctvMatchService {
+    private final CctvDetectionRepository cctvDetectionRepository;
+    private final CctvDetectionMatchRepository cctvDetectionMatchRepository;
+    private final ItemRepository itemRepository;
+    @Value("${zoopick.similarity.threshold}")
+    private float similarityThreshold;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void matchCctvToLostItems(Long detectionId) {
+        log.info("[CCTV] 매칭 시작 ID: {}", detectionId);
+        CctvDetection cctvDetection = cctvDetectionRepository.findById(detectionId).orElse(null);
+        Vector embedding = Vector.of(cctvDetection.getEmbedding());
+        List<SimilarItemResult> similarItems = cctvDetectionMatchRepository.findLostItems(
+                        embedding,
+                        cctvDetection.getDetectedCategory().name(),
+                        similarityThreshold)
+                .stream()
+                .map(p -> new SimilarItemResult(p.getItemId(), p.getScore()))
+                .toList();
+
+        if (similarItems.isEmpty()) {
+            log.warn("[CCTV] 매칭된 아이템이 없습니다.");
+            return;
+        }
+        Map<Long, Item> itemMap = itemRepository.findAllById(
+                        similarItems.stream().map(SimilarItemResult::getItemId).toList())
+                .stream()
+                .collect(Collectors.toMap(Item::getId, i -> i));
+
+        for (SimilarItemResult s : similarItems) {
+            // 중복 저장 방지
+            Item foundItemInDb = itemMap.get(s.getItemId());
+            if (!cctvDetectionMatchRepository.existsByCctvDetectionAndItem(cctvDetection, foundItemInDb)) {
+                CctvDetectionMatch savedMatch = cctvDetectionMatchRepository.save(CctvDetectionMatch.builder()
+                        .score((float) s.getScore())
+                        .item(foundItemInDb)
+                        .cctvDetection(cctvDetection)
+                        .build());
+                log.info("CCTV 매칭된 아이템 ID: {}", foundItemInDb.getId());
+                //TODO: 이벤트 퍼블리싱으로 FCM 보내기
+            }
+        }
+        log.info("[CCTV] 매칭 종료 ID: {}", detectionId);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void matchLostItemsToCctv(Long lostItemId) {
+        log.info("[CCTV] 매칭 시작 ID: {}", lostItemId);
+        Item lostItem = itemRepository.findByIdOrThrow(lostItemId);
+        Vector embedding = Vector.of(lostItem.getEmbedding());
+        List<SimilarItemResult> similarItems = cctvDetectionMatchRepository.findDetections(
+                        embedding,
+                        lostItem.getCategory().name(),
+                        similarityThreshold)
+                .stream()
+                .map(p -> new SimilarItemResult(p.getItemId(), p.getScore()))
+                .toList();
+
+        if (similarItems.isEmpty()) {
+            log.warn("[CCTV] 매칭된 Detection이 없습니다.");
+            return;
+        }
+        Map<Long, CctvDetection> detectionMap = cctvDetectionRepository.findAllById(
+                        similarItems.stream().map(SimilarItemResult::getItemId).toList())
+                .stream()
+                .collect(Collectors.toMap(CctvDetection::getId, i -> i));
+
+        for (SimilarItemResult s : similarItems) {
+            // 중복 저장 방지
+            CctvDetection foundItemInDb = detectionMap.get(s.getItemId());
+            if (foundItemInDb == null) {
+                log.error("검색 결과에는 있으나 DB 조회에 실패한 Detection ID: {}", s.getItemId());
+                continue;
+            }
+            if (!cctvDetectionMatchRepository.existsByCctvDetectionAndItem(foundItemInDb, lostItem)) {
+                CctvDetectionMatch savedMatch = cctvDetectionMatchRepository.save(CctvDetectionMatch.builder()
+                        .score((float) s.getScore())
+                        .item(lostItem)
+                        .cctvDetection(foundItemInDb)
+                        .build());
+                log.info("[CCTV] 매칭된 Detection ID: {}", foundItemInDb.getId());
+                //TODO: 이벤트 퍼블리싱으로 FCM 보내기
+            }
+        }
+        log.info("[CCTV] 매칭 종료 ID: {}", lostItemId);
+    }
+}

--- a/src/main/java/com/zoopick/server/service/CctvService.java
+++ b/src/main/java/com/zoopick/server/service/CctvService.java
@@ -6,6 +6,7 @@ import com.zoopick.server.dto.match.SaveCctvDetectionEvent;
 import com.zoopick.server.entity.*;
 import com.zoopick.server.exception.BadRequestException;
 import com.zoopick.server.exception.DataNotFoundException;
+import com.zoopick.server.exception.ForbiddenException;
 import com.zoopick.server.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -297,7 +298,7 @@ public class CctvService {
     }
 
     public GetDetectionsMeResponse getDetectionsMe(Long userId) {
-        List<MatchedLostItems> matchedLostItems = cctvDetectionMatchRepository.findCctvDetectionByUserId(userId);
+        List<MatchedLostItems> matchedLostItems = cctvDetectionRepository.findCctvDetectionByUserId(userId);
         return new GetDetectionsMeResponse(matchedLostItems);
     }
 
@@ -311,5 +312,29 @@ public class CctvService {
         );
 
         return new GetDetectionByItemIdResponse(cctvDetectionDetail);
+    }
+
+    @Transactional
+    public void reviewMatch(Long userId, Long detectionId, CctvDetectionReviewRequest request) {
+        CctvDetection detection = cctvDetectionRepository.findById(detectionId)
+                .orElseThrow(() -> DataNotFoundException.from("CCTV 탐지 정보", detectionId));
+        if (detection.getReviewStatus() != DetectionReviewStatus.PENDING) {
+            log.info("[CCTV] 이미 처리된 Detection입니다. DetectionId={}, Status={}", detectionId, detection.getReviewStatus());
+            return;
+        }
+        boolean existsMatch = cctvDetectionMatchRepository.existsByCctvDetectionIdAndItemReporterId(detectionId, userId);
+        if (!existsMatch) {
+            throw new ForbiddenException("Detection에 대한 접근 권한이 없습니다.");
+        }
+        CctvDetectionMatch cctvDetectionMatch = cctvDetectionMatchRepository.findByCctvDetectionIdAndItemReporterId(detectionId, userId);
+        if (request.getReviewStatus() == DetectionReviewStatus.CONFIRMED_SELF) {
+            Item lostItem = cctvDetectionMatch.getItem();
+            lostItem.theftSuspected(LocalDateTime.now());
+            log.info("[CCTV] 도난 상태 저장 완료: itemId={}", lostItem.getId());
+        }
+
+        detection.updateDetectionReviewStatus(request.getReviewStatus());
+
+        log.info("[CCTV] 리뷰 상태 변경: DetectionId={}, Status={}", detectionId, request.getReviewStatus());
     }
 }

--- a/src/main/java/com/zoopick/server/service/CctvService.java
+++ b/src/main/java/com/zoopick/server/service/CctvService.java
@@ -259,8 +259,7 @@ public class CctvService {
                         entity.getCctvVideo().getId(),
                         entity.getDetectedAt(),
                         entity.getDetectedCategory(),
-                        entity.getDetectedColor(),
-                        entity.getReviewStatus()
+                        entity.getDetectedColor()
                 ))
                 .toList();
     }
@@ -279,8 +278,6 @@ public class CctvService {
                 entity.getEmbedding(),
                 entity.getItemSnapshotUrl(),
                 entity.getMomentSnapshotUrl(),
-                entity.getReviewStatus(),
-                entity.getReviewedAt(),
                 entity.getCreatedAt()
         );
     }
@@ -298,12 +295,12 @@ public class CctvService {
     }
 
     public GetDetectionsMeResponse getDetectionsMe(Long userId) {
-        List<MatchedLostItems> matchedLostItems = cctvDetectionRepository.findCctvDetectionByUserId(userId);
+        List<MatchedLostItems> matchedLostItems = cctvDetectionRepository.findCctvDetectionByUserId(userId, DetectionReviewStatus.PENDING);
         return new GetDetectionsMeResponse(matchedLostItems);
     }
 
     public GetDetectionByItemIdResponse getDetectionsMeByItemId(Long userId, Long itemId) {
-        List<CctvDetectionDetail> cctvDetectionDetail = cctvDetectionRepository.findCctvDetectionDetail(userId, itemId);
+        List<CctvDetectionDetail> cctvDetectionDetail = cctvDetectionRepository.findCctvDetectionDetail(userId, itemId, DetectionReviewStatus.PENDING);
 
         cctvDetectionDetail.forEach(d ->
                 d.setScore(BigDecimal.valueOf(d.getScore())
@@ -315,26 +312,31 @@ public class CctvService {
     }
 
     @Transactional
-    public void reviewMatch(Long userId, Long detectionId, CctvDetectionReviewRequest request) {
-        CctvDetection detection = cctvDetectionRepository.findById(detectionId)
-                .orElseThrow(() -> DataNotFoundException.from("CCTV 탐지 정보", detectionId));
-        if (detection.getReviewStatus() != DetectionReviewStatus.PENDING) {
-            log.info("[CCTV] 이미 처리된 Detection입니다. DetectionId={}, Status={}", detectionId, detection.getReviewStatus());
+    public void reviewMatch(Long userId, Long matchId, CctvDetectionReviewRequest request) {
+        CctvDetectionMatch cctvDetectionMatch = cctvDetectionMatchRepository.findById(matchId)
+                .orElseThrow(() -> DataNotFoundException.from("CCTV 매칭", matchId));
+        if (!cctvDetectionMatch.getItem().getReporter().getId().equals(userId)) {
+            log.warn("[CCTV] 권한 없는 사용자의 리뷰 시도: userId={}, matchId={}", userId, matchId);
+            throw new ForbiddenException("해당 매칭 정보를 수정할 권한이 없습니다.");
+        }
+        if (cctvDetectionMatch.getReviewStatus() != DetectionReviewStatus.PENDING) {
+            log.info("[CCTV] 이미 처리된 Detection입니다. matchId={}, Status={}", matchId, cctvDetectionMatch.getReviewStatus());
             return;
         }
-        boolean existsMatch = cctvDetectionMatchRepository.existsByCctvDetectionIdAndItemReporterId(detectionId, userId);
-        if (!existsMatch) {
-            throw new ForbiddenException("Detection에 대한 접근 권한이 없습니다.");
-        }
-        CctvDetectionMatch cctvDetectionMatch = cctvDetectionMatchRepository.findByCctvDetectionIdAndItemReporterId(detectionId, userId);
         if (request.getReviewStatus() == DetectionReviewStatus.CONFIRMED_SELF) {
             Item lostItem = cctvDetectionMatch.getItem();
             lostItem.theftSuspected(LocalDateTime.now());
+            cctvDetectionMatchRepository.rejectOtherPendingMatches( // 나머지 reject 처리
+                    lostItem.getId(),
+                    matchId,
+                    DetectionReviewStatus.REJECTED_SELF,
+                    DetectionReviewStatus.PENDING,
+                    LocalDateTime.now());
             log.info("[CCTV] 도난 상태 저장 완료: itemId={}", lostItem.getId());
         }
 
-        detection.updateDetectionReviewStatus(request.getReviewStatus());
+        cctvDetectionMatch.updateDetectionReviewStatus(request.getReviewStatus());
 
-        log.info("[CCTV] 리뷰 상태 변경: DetectionId={}, Status={}", detectionId, request.getReviewStatus());
+        log.info("[CCTV] 리뷰 상태 변경: MatchId={}, Status={}", matchId, request.getReviewStatus());
     }
 }

--- a/src/main/java/com/zoopick/server/service/CctvService.java
+++ b/src/main/java/com/zoopick/server/service/CctvService.java
@@ -18,6 +18,8 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -297,5 +299,17 @@ public class CctvService {
     public GetDetectionsMeResponse getDetectionsMe(Long userId) {
         List<MatchedLostItems> matchedLostItems = cctvDetectionMatchRepository.findCctvDetectionByUserId(userId);
         return new GetDetectionsMeResponse(matchedLostItems);
+    }
+
+    public GetDetectionByItemIdResponse getDetectionsMeByItemId(Long userId, Long itemId) {
+        List<CctvDetectionDetail> cctvDetectionDetail = cctvDetectionRepository.findCctvDetectionDetail(userId, itemId);
+
+        cctvDetectionDetail.forEach(d ->
+                d.setScore(BigDecimal.valueOf(d.getScore())
+                        .setScale(3, RoundingMode.HALF_UP)
+                        .doubleValue())
+        );
+
+        return new GetDetectionByItemIdResponse(cctvDetectionDetail);
     }
 }

--- a/src/main/java/com/zoopick/server/service/CctvService.java
+++ b/src/main/java/com/zoopick/server/service/CctvService.java
@@ -2,6 +2,7 @@ package com.zoopick.server.service;
 
 import com.zoopick.server.config.FastApiProperties;
 import com.zoopick.server.dto.cctv.*;
+import com.zoopick.server.dto.match.SaveCctvDetectionEvent;
 import com.zoopick.server.entity.*;
 import com.zoopick.server.exception.BadRequestException;
 import com.zoopick.server.exception.DataNotFoundException;
@@ -12,6 +13,7 @@ import com.zoopick.server.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,7 +42,7 @@ public class CctvService {
     private final StringRedisTemplate stringRedisTemplate;
     private final RestClient fastApiRestClient;
     private final FastApiProperties fastApiProperties;
-
+    private final ApplicationEventPublisher eventPublisher;
     @Value("${zoopick.callback-url}")
     private String callbackBaseUrl;
 
@@ -199,6 +201,7 @@ public class CctvService {
             CctvDetection savedDetection = cctvDetectionRepository.save(detection);
             log.info("New detection registered: video_id={}, ai_detection_id={}",
                     callback.getVideoId(), callback.getDetectionId());
+            eventPublisher.publishEvent(new SaveCctvDetectionEvent(savedDetection.getId()));
             return new DetectionRegisterResult(false, savedDetection.getId());
         } catch (RuntimeException e) {
             stringRedisTemplate.delete(idempotencyKey);

--- a/src/main/java/com/zoopick/server/service/CctvService.java
+++ b/src/main/java/com/zoopick/server/service/CctvService.java
@@ -6,10 +6,7 @@ import com.zoopick.server.dto.match.SaveCctvDetectionEvent;
 import com.zoopick.server.entity.*;
 import com.zoopick.server.exception.BadRequestException;
 import com.zoopick.server.exception.DataNotFoundException;
-import com.zoopick.server.repository.CctvDetectionRepository;
-import com.zoopick.server.repository.CctvVideoProgressRepository;
-import com.zoopick.server.repository.CctvVideoRepository;
-import com.zoopick.server.repository.RoomRepository;
+import com.zoopick.server.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -43,6 +40,7 @@ public class CctvService {
     private final RestClient fastApiRestClient;
     private final FastApiProperties fastApiProperties;
     private final ApplicationEventPublisher eventPublisher;
+    private final CctvDetectionMatchRepository cctvDetectionMatchRepository;
     @Value("${zoopick.callback-url}")
     private String callbackBaseUrl;
 
@@ -222,7 +220,6 @@ public class CctvService {
         cctvVideoProgressRepository.save(progress);
         log.info("CCTV Video analysis completed: video_id={}, total_detections={}",
                 callback.getVideoId(), callback.getTotalDetections());
-        // TODO: 매칭 트리거 및 알림 로직 추가
     }
 
     @Transactional
@@ -295,5 +292,10 @@ public class CctvService {
 
         //return target.toAbsolutePath().toString(); 절대경로 반환
         return "backend/storage/cctv/videos/" + filename; // 상대경로
+    }
+
+    public GetDetectionsMeResponse getDetectionsMe(Long userId) {
+        List<MatchedLostItems> matchedLostItems = cctvDetectionMatchRepository.findCctvDetectionByUserId(userId);
+        return new GetDetectionsMeResponse(matchedLostItems);
     }
 }

--- a/src/main/java/com/zoopick/server/service/CreateCctvMatchEventListner.java
+++ b/src/main/java/com/zoopick/server/service/CreateCctvMatchEventListner.java
@@ -25,15 +25,12 @@ public class CreateCctvMatchEventListner {
         Room room = event.cctvDetection().getCctvVideo().getRoom();
         Item item = event.item();
         CctvDetectionMatch cctvDetectionMatch = event.cctvDetectionMatch();
-        CctvDetection cctvDetection = event.cctvDetection();
         String title = event.itemPost().getTitle();
 
         notificationService.send(event.item().getReporter(), new SendNotificationCommand(
                 "도난 의심",
-                "회원님이 등록한 %s와 유사한 물건이 %s에서 발견됐어요.".formatted(title, room.getName()),
-                CctvFoundPayload.of(item, cctvDetectionMatch)
-            )
-        );
+                "회원님이 등록한 %s와 유사한 물건이 %s에서 도난이 의심돼요.".formatted(title, room.getName()),
+                CctvFoundPayload.of(item, cctvDetectionMatch)));
         log.info("FCM 전송 성공 matchId: {}", cctvDetectionMatch.getId());
     }
 }

--- a/src/main/java/com/zoopick/server/service/CreateCctvMatchEventListner.java
+++ b/src/main/java/com/zoopick/server/service/CreateCctvMatchEventListner.java
@@ -1,0 +1,39 @@
+package com.zoopick.server.service;
+
+import com.zoopick.server.dto.match.CreateCctvMatchEvent;
+import com.zoopick.server.entity.*;
+import com.zoopick.server.service.notification.NotificationService;
+import com.zoopick.server.service.notification.SendNotificationCommand;
+import com.zoopick.server.service.notification.payload.CctvFoundPayload;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CreateCctvMatchEventListner {
+    private final NotificationService notificationService;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleMatchCreated(CreateCctvMatchEvent event) {
+        Room room = event.cctvDetection().getCctvVideo().getRoom();
+        Item item = event.item();
+        CctvDetectionMatch cctvDetectionMatch = event.cctvDetectionMatch();
+        CctvDetection cctvDetection = event.cctvDetection();
+        String title = event.itemPost().getTitle();
+
+        notificationService.send(event.item().getReporter(), new SendNotificationCommand(
+                "도난 의심",
+                "회원님이 등록한 %s와 유사한 물건이 %s에서 발견됐어요.".formatted(title, room.getName()),
+                CctvFoundPayload.of(item, cctvDetectionMatch)
+            )
+        );
+        log.info("FCM 전송 성공 matchId: {}", cctvDetectionMatch.getId());
+    }
+}

--- a/src/main/java/com/zoopick/server/service/CreateMatchEventListner.java
+++ b/src/main/java/com/zoopick/server/service/CreateMatchEventListner.java
@@ -4,9 +4,7 @@ import com.zoopick.server.dto.match.CreateMatchEvent;
 import com.zoopick.server.entity.Item;
 import com.zoopick.server.entity.ItemMatch;
 import com.zoopick.server.entity.MatchStatus;
-import com.zoopick.server.repository.ItemMatchRepository;
 import com.zoopick.server.repository.ItemPostRepository;
-import com.zoopick.server.repository.ItemRepository;
 import com.zoopick.server.service.notification.NotificationService;
 import com.zoopick.server.service.notification.SendNotificationCommand;
 import com.zoopick.server.service.notification.payload.MatchFoundPayload;
@@ -23,16 +21,14 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Slf4j
 public class CreateMatchEventListner {
     private final NotificationService notificationService;
-    private final ItemMatchRepository itemMatchRepository;
     private final ItemPostRepository itemPostRepository;
-    private final ItemRepository itemRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMatchCreated(CreateMatchEvent event) {
-        ItemMatch match = itemMatchRepository.findByIdOrThrow(event.matchId());
-        Item lostItem = itemRepository.findByIdOrThrow(event.lostItemId());
-        Item foundItem = itemRepository.findByIdOrThrow(event.foundItemId());
+        ItemMatch match = event.match();
+        Item lostItem = event.lostItem();
+        Item foundItem = event.foundItem();
         String title = itemPostRepository.findByItem(lostItem).getTitle();
         String location = foundItem.getLocationName();
         notificationService.send(lostItem.getReporter(), new SendNotificationCommand(

--- a/src/main/java/com/zoopick/server/service/ItemMatchService.java
+++ b/src/main/java/com/zoopick/server/service/ItemMatchService.java
@@ -81,7 +81,7 @@ public class ItemMatchService {
                         .status(MatchStatus.CANDIDATE)
                         .build());
                 log.info("매칭된 아이템 ID: {}", foundItemInDb.getId());
-                eventPublisher.publishEvent(new CreateMatchEvent(savedMatch.getId(), lostItem.getId(), foundItem.getId()));
+                eventPublisher.publishEvent(new CreateMatchEvent(savedMatch, lostItem, foundItem));
             }
         }
         log.info("매칭 종료 ID: {}", targetItem.getId());

--- a/src/main/java/com/zoopick/server/service/ItemMatchService.java
+++ b/src/main/java/com/zoopick/server/service/ItemMatchService.java
@@ -1,5 +1,6 @@
 package com.zoopick.server.service;
 
+import com.zoopick.server.config.MatchConfig;
 import com.zoopick.server.dto.match.*;
 import com.zoopick.server.entity.*;
 import com.zoopick.server.exception.BadRequestException;
@@ -8,7 +9,6 @@ import com.zoopick.server.repository.ItemRepository;
 import com.zoopick.server.repository.LockerRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Vector;
 import org.springframework.stereotype.Service;
@@ -27,8 +27,7 @@ public class ItemMatchService {
     private final ItemMatchRepository itemMatchRepository;
     private final LockerRepository lockerRepository;
     private final ApplicationEventPublisher eventPublisher;
-    @Value("${zoopick.similarity.threshold}")
-    private float similarityThreshold;
+    private final MatchConfig matchConfig;
 
     @Transactional
     public void createMatch(Long itemId) {
@@ -40,7 +39,7 @@ public class ItemMatchService {
                         targetItem.getType().name(),
                         targetItem.getCategory().name(),
                         targetItem.getReporter().getId(),
-                        similarityThreshold)
+                        matchConfig.getSimilarityThreshold())
                 .stream()
                 .map(p -> new SimilarItemResult(p.getItemId(), p.getScore()))
                 .toList();
@@ -59,7 +58,7 @@ public class ItemMatchService {
                 .map(s -> {
                     Item found = itemMap.get(s.getItemId());
                     float score = (float) s.getScore();
-                    if (targetItem.getColor() == found.getColor()) score *= 1.02f;
+                    if (targetItem.getColor() == found.getColor()) score *= matchConfig.getColorBonus();
                     return new SimilarItemResult(s.getItemId(), Math.min(score, 1.0f));
                 })
                 .sorted(Comparator.comparingDouble(SimilarItemResult::getScore).reversed())

--- a/src/main/java/com/zoopick/server/service/ItemPostService.java
+++ b/src/main/java/com/zoopick/server/service/ItemPostService.java
@@ -48,7 +48,7 @@ public class ItemPostService {
                 .build();
 
         Item savedItem = itemRepository.save(item);
-        eventPublisher.publishEvent(new ItemCreatedEvent(savedItem.getId()));
+        eventPublisher.publishEvent(new ItemCreatedEvent(savedItem.getId(), item.getType()));
 
         ItemPost itemPost = ItemPost.builder()
                 .title(request.getTitle())

--- a/src/main/java/com/zoopick/server/service/SaveCctvDetectionListner.java
+++ b/src/main/java/com/zoopick/server/service/SaveCctvDetectionListner.java
@@ -1,7 +1,7 @@
 package com.zoopick.server.service;
 
-import com.zoopick.server.dto.item.ItemCreatedEvent;
-import com.zoopick.server.entity.ItemType;
+
+import com.zoopick.server.dto.match.SaveCctvDetectionEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -12,16 +12,12 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class ItemPostEventListner {
-    private final VisionService visionService;
+public class SaveCctvDetectionListner {
     private final CctvMatchService cctvMatchService;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleItemCreated(ItemCreatedEvent event) {
-        visionService.analyzeImage(event.itemId()); //이미지 분석 실행
-
-        if (event.itemType() == ItemType.LOST) // ItemType이 Lost인 경우 cctv 분석 실행
-            cctvMatchService.matchLostItemsToCctv(event.itemId());
+    public void handleMatchCctvToLostItems(SaveCctvDetectionEvent event) {
+        cctvMatchService.matchCctvToLostItems(event.detectionId());
     }
 }

--- a/src/main/java/com/zoopick/server/service/VisionService.java
+++ b/src/main/java/com/zoopick/server/service/VisionService.java
@@ -11,6 +11,7 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClient;
 
@@ -23,7 +24,7 @@ public class VisionService {
     private final ItemRepository itemRepository;
     private final ItemMatchService itemMatchService;
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void analyzeImage(Long itemId) {
         log.info("전달된 아이템 ID: {}", itemId);
         Item item = itemRepository.findById(itemId).orElseThrow(() -> new EntityNotFoundException("아이템을 찾을 수 없습니다."));

--- a/src/main/java/com/zoopick/server/service/notification/payload/CctvFoundPayload.java
+++ b/src/main/java/com/zoopick/server/service/notification/payload/CctvFoundPayload.java
@@ -1,0 +1,47 @@
+package com.zoopick.server.service.notification.payload;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.zoopick.server.entity.CctvDetectionMatch;
+import com.zoopick.server.entity.Item;
+import com.zoopick.server.entity.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Map;
+
+@NullMarked
+@Schema(
+        name = "CctvFoundPayload",
+        description = "CCTV_FOUND : CCTV 매칭 발견 알림 payload"
+)
+public record CctvFoundPayload(
+        @JsonProperty("item_id")
+        @Schema(description = "분실물 ID", example = "10")
+        long itemId,
+
+        @JsonProperty("match_id")
+        @Schema(description = "Detection 매칭 ID", example = "55")
+        long matchId,
+
+        @JsonProperty("score")
+        @Schema(description = "매칭 점수", example = "0.87")
+        float score
+) implements NotificationPayload {
+    public static CctvFoundPayload of(Item item, CctvDetectionMatch cctvDetectionMatch) {
+        return new CctvFoundPayload(item.getId(), cctvDetectionMatch.getId(), cctvDetectionMatch.getScore());
+    }
+
+    @Override
+    public NotificationType type() {
+        return NotificationType.CCTV_FOUND;
+    }
+
+    @Override
+    public Map<String, String> toMap() {
+        return Map.of(
+                "item_id", String.valueOf(itemId),
+                "match_id", String.valueOf(matchId),
+                "score", String.valueOf(score)
+        );
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,4 +45,5 @@ zoopick.base-url=${ZOOPICK_BASE_URL:http://localhost:8080}
 zoopick.cctv.storage-absolute-dir=${ZOOPICK_CCTV_STORAGE_ABSOLUTE_DIR:/absolute_path/storage/}
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=20MB
-zoopick.similarity.threshold=${ZOOPICK_SIMILARITY_THRESHOLD:0.85}
+zoopick.match.similarity-threshold=${ZOOPICK_SIMILARITY_THRESHOLD:0.85}
+zoopick.match.color-bonus=${ZOOPICK_COLOR_BONUS:1.02}

--- a/zoopick_dump.sql
+++ b/zoopick_dump.sql
@@ -312,7 +312,9 @@ CREATE TABLE zoopick.cctv_detection_matches (
                                                 id bigint NOT NULL,
                                                 detection_id bigint NOT NULL,
                                                 item_id bigint NOT NULL,
-                                                score real NOT NULL
+                                                score real NOT NULL,
+                                                review_status zoopick.detection_review_status DEFAULT 'PENDING'::zoopick.detection_review_status NOT NULL,
+                                                reviewed_at timestamp without time zone
 );
 
 
@@ -352,8 +354,6 @@ CREATE TABLE zoopick.cctv_detections (
                                          embedding zoopick.vector(512),
                                          item_snapshot_url character varying(500) NOT NULL,
                                          moment_snapshot_url character varying(500) NOT NULL,
-                                         review_status zoopick.detection_review_status DEFAULT 'PENDING'::zoopick.detection_review_status NOT NULL,
-                                         reviewed_at timestamp without time zone,
                                          created_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
@@ -1083,7 +1083,7 @@ COPY zoopick.buildings (id, name, code, latitude, longitude) FROM stdin;
 -- Data for Name: cctv_detection_matches; Type: TABLE DATA; Schema: zoopick; Owner: postgres
 --
 
-COPY zoopick.cctv_detection_matches (id, detection_id, item_id, score) FROM stdin;
+COPY zoopick.cctv_detection_matches (id, detection_id, item_id, score, review_status, reviewed_at) FROM stdin;
 \.
 
 
@@ -1091,7 +1091,7 @@ COPY zoopick.cctv_detection_matches (id, detection_id, item_id, score) FROM stdi
 -- Data for Name: cctv_detections; Type: TABLE DATA; Schema: zoopick; Owner: postgres
 --
 
-COPY zoopick.cctv_detections (id, video_id, detected_at, detected_category, detected_color, embedding, item_snapshot_url, moment_snapshot_url, review_status, reviewed_at, created_at) FROM stdin;
+COPY zoopick.cctv_detections (id, video_id, detected_at, detected_category, detected_color, embedding, item_snapshot_url, moment_snapshot_url, created_at) FROM stdin;
 \.
 
 
@@ -1731,10 +1731,10 @@ CREATE INDEX idx_courses_semester ON zoopick.courses USING btree (year, semester
 
 
 --
--- Name: idx_detections_pending; Type: INDEX; Schema: zoopick; Owner: postgres
+-- Name: idx_detection_matches_pending; Type: INDEX; Schema: zoopick; Owner: postgres
 --
 
-CREATE INDEX idx_detections_pending ON zoopick.cctv_detections USING btree (review_status) WHERE (review_status = 'PENDING'::zoopick.detection_review_status);
+CREATE INDEX idx_detection_matches_pending ON zoopick.cctv_detection_matches USING btree (review_status) WHERE (review_status = 'PENDING'::zoopick.detection_review_status);
 
 
 --

--- a/zoopick_dump.sql
+++ b/zoopick_dump.sql
@@ -228,6 +228,7 @@ ALTER TYPE zoopick.match_status OWNER TO postgres;
 
 CREATE TYPE zoopick.notification_type AS ENUM (
     'MATCH_FOUND',
+    'CCTV_FOUND',
     'CHAT_MESSAGE',
     'ITEM_RETURNED',
     'THEFT_SUSPECTED',

--- a/zoopick_dump.sql
+++ b/zoopick_dump.sql
@@ -310,7 +310,8 @@ ALTER SEQUENCE zoopick.buildings_id_seq OWNED BY zoopick.buildings.id;
 CREATE TABLE zoopick.cctv_detection_matches (
                                                 id bigint NOT NULL,
                                                 detection_id bigint NOT NULL,
-                                                item_id bigint NOT NULL
+                                                item_id bigint NOT NULL,
+                                                score real NOT NULL
 );
 
 
@@ -1081,7 +1082,7 @@ COPY zoopick.buildings (id, name, code, latitude, longitude) FROM stdin;
 -- Data for Name: cctv_detection_matches; Type: TABLE DATA; Schema: zoopick; Owner: postgres
 --
 
-COPY zoopick.cctv_detection_matches (id, detection_id, item_id) FROM stdin;
+COPY zoopick.cctv_detection_matches (id, detection_id, item_id, score) FROM stdin;
 \.
 
 


### PR DESCRIPTION
# feat: CCTV-분실물 AI 매칭 기능 구현 및 매칭 리뷰 API 추가

## 개요

CCTV AI 분석 결과와 유저의 분실물 등록 정보를 코사인 유사도 기반으로 자동 매칭하는 기능을 구현했습니다. 매칭 결과를 유저가 직접 확인/거절할 수 있는 리뷰 API도 함께 추가되었습니다.

---

## 주요 변경 사항

### ✨ 신규 기능

**CCTV 매칭 엔진 (`CctvMatchService`)**
- CCTV 탐지 완료 시 → 유사 분실물 자동 매칭 (`matchCctvToLostItems`)
- 분실물 등록 시 → 기존 CCTV 탐지 결과와 역방향 매칭 (`matchLostItemsToCctv`)
- 코사인 유사도 임계값 필터링 후 색상 일치 시 가산점 부여 (`colorBonus`)
- 중복 매칭 방지 로직 포함

**매칭 기준 컨텍스트 분석 (`CctvMatchCriteriaResolver`)**
- 유저의 시간표 정보를 기반으로 분실 시점에 있었던 강의실 범위를 추론
- 정확한 강의실 특정 가능 시 해당 강의실만, 불가능 시 건물 내 전체 강의실로 탐색 범위 설정

**매칭 조회 API**
- `GET /api/cctv/detections/me` — 내 분실물 중 CCTV 매칭 이력이 있는 목록 조회
- `GET /api/cctv/detections/me?itemId={id}` — 특정 분실물에 매칭된 CCTV 상세 정보 조회 (시간, 장소, 스코어, 스냅샷)

**매칭 리뷰 API**
- `PUT /api/cctv/detections/{matchId}/review` — 매칭 결과 확정(`CONFIRMED_SELF`) 또는 거절(`REJECTED_SELF`) 처리
- 확정 시 해당 분실물의 나머지 pending 매칭 자동 일괄 거절

**알림 (`CctvFoundPayload`)**
- CCTV 매칭 발생 시 `CCTV_FOUND` 타입 알림 전송

---

### ♻️ 리팩토링 / 구조 변경

**DB 스키마 변경**
- `review_status`, `reviewed_at` 필드를 `cctv_detections`에서 `cctv_detection_matches`로 이동 (리뷰는 Detection이 아닌 Match 단위로 관리)
- `cctv_detection_matches`에 `score` 컬럼 추가
- 인덱스명 `idx_detections_pending` → `idx_detection_matches_pending`으로 변경
- `notificationtype` enum에 CCTVFOUND 값 추가

**설정 구조 개선 (`MatchConfig`)**
- 기존 `zoopick.similarity.threshold` 단일 프로퍼티를 `zoopick.match.*` 네임스페이스로 통합
- `similarityThreshold`, `colorBonus` 값을 `@ConfigurationProperties`로 타입 안전하게 관리

**이벤트 구조 개선**
- `ItemCreatedEvent`에 `ItemType` 추가 → 분실물 등록 시에만 CCTV 매칭 이벤트 발행
- `CreateMatchEvent` 페이로드를 ID 기반에서 엔티티 객체 기반으로 변경
- `SaveCctvDetectionListner`: 트랜잭션 커밋 후 비동기 이벤트로 CCTV 매칭 처리 (`@Async` + `AFTER_COMMIT`)

**트랜잭션**
- `VisionService.analyzeImage()` → `REQUIRES_NEW` 전파 레벨로 변경 (독립 트랜잭션 보장)

**보안**
- `/api/cctv/upload` 엔드포인트의 중복 `permitAll()` 제거

---

## 테스트 포인트

- [x] 분실물 등록 시 임계값 이상 유사한 CCTV 탐지 결과와 매칭되는지 확인
- [x] CCTV 분석 완료 후 기존 분실물과 매칭되는지 확인
- [ ] 시간표 정보 있을 때 강의실 범위가 좁혀지는지 확인
- [x] 매칭 확정 시 동일 분실물의 다른 pending 매칭이 자동 거절되는지 확인
- [x] 색상 일치 시 가산점이 반영되어 score가 올라가는지 확인
- [x] `CCTV_FOUND` 알림이 정상 전송되는지 확인

시간표는 제가 안드로이드에서 한국어 검색이 아예 안돼서 테스트 못 해봤습니다.
시간표 제외 다른 cctv 매칭의 경우는 잘 작동됩니다.
---

## 변경 API
`/api/cctv/detections/me?itemId={id} `
```
  Response 200:
  {
    "success": true,
    "data": {
      "detections": [
        {
          "match_id": 1, <- match_id로 반환해서 드립니다!!
          "score": 0.978,
          "detected_at": "2026-05-13 14:20",
          "building_name": "제1공학관",
          "room_name": "Y106",
          "item_snapshot_url": "/storage/cctv/snapshots/item_1.jpg",
          "moment_snapshot_url": "/storage/cctv/snapshots/moment_1.jpg"
        },
        {
          "match_id": 6, <- match_id로 반환해서 드립니다!!
          "score": 0.923,
          "detected_at": "2026-05-12 11:20",
          "building_name": "제1공학관",
          "room_name": "Y117",
          "item_snapshot_url": "/storage/cctv/snapshots/item_6.jpg",
          "moment_snapshot_url": "/storage/cctv/snapshots/moment_6.jpg"
        }
      ]
    },
    "error": null
  }
```
## detectionId -> matchId로 주시면 됩니다.  (나머지 변경 X)
`/api/cctv/detections/{detectionId}/review ` -> `/api/cctv/detections/{matchId}/review `
```
Request Body

{
  "review_status": "CONFIRMED_SELF" // "CONFIRMED_SELF" | "REJECTED_SELF"
}
```
```
Response (200 OK)

{
  "success": true,
  "data": null
}
```