### PR TITLE
Feat & Fix: locker column 락커넘버 1 테이블 트랜젝션 버그 픽스

### DIFF
--- a/src/main/java/com/zoopick/server/dto/cctv/CctvDetectionReviewRequest.java
+++ b/src/main/java/com/zoopick/server/dto/cctv/CctvDetectionReviewRequest.java
@@ -5,10 +5,12 @@ import com.zoopick.server.entity.DetectionReviewStatus;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @AllArgsConstructor
 public class CctvDetectionReviewRequest {
     @NotNull

--- a/src/main/java/com/zoopick/server/dto/match/CreateCctvMatchEvent.java
+++ b/src/main/java/com/zoopick/server/dto/match/CreateCctvMatchEvent.java
@@ -4,6 +4,7 @@ import com.zoopick.server.entity.CctvDetection;
 import com.zoopick.server.entity.CctvDetectionMatch;
 import com.zoopick.server.entity.Item;
 import com.zoopick.server.entity.ItemPost;
+import com.zoopick.server.entity.Room;
 
-public record CreateCctvMatchEvent(Item item, CctvDetectionMatch cctvDetectionMatch, CctvDetection cctvDetection, ItemPost itemPost) {
+public record CreateCctvMatchEvent(Item item, CctvDetectionMatch cctvDetectionMatch, CctvDetection cctvDetection, ItemPost itemPost, Room room) {
 }

--- a/src/main/java/com/zoopick/server/service/CctvMatchService.java
+++ b/src/main/java/com/zoopick/server/service/CctvMatchService.java
@@ -93,7 +93,8 @@ public class CctvMatchService {
                         .cctvDetection(cctvDetection)
                         .build());
                 log.info("CCTV 매칭된 아이템 ID: {}", lostItem.getId());
-                eventPublisher.publishEvent(new CreateCctvMatchEvent(lostItem, savedMatch, cctvDetection, itemPost));
+                Room room = cctvDetection.getCctvVideo().getRoom();
+                eventPublisher.publishEvent(new CreateCctvMatchEvent(lostItem, savedMatch, cctvDetection, itemPost, room));
             }
         }
         log.info("[CCTV] 매칭 종료 ID: {}", detectionId);
@@ -146,8 +147,9 @@ public class CctvMatchService {
                         .cctvDetection(foundItemInDb)
                         .build());
                 log.info("[CCTV] 매칭된 Detection ID: {}", foundItemInDb.getId());
+                Room foundRoom = foundItemInDb.getCctvVideo().getRoom();
                 eventPublisher
-                        .publishEvent(new CreateCctvMatchEvent(lostItem, savedMatch, foundItemInDb, lostItemPost));
+                        .publishEvent(new CreateCctvMatchEvent(lostItem, savedMatch, foundItemInDb, lostItemPost, foundRoom));
             }
         }
         log.info("[CCTV] 매칭 종료 ID: {}", lostItemId);

--- a/src/main/java/com/zoopick/server/service/CctvService.java
+++ b/src/main/java/com/zoopick/server/service/CctvService.java
@@ -319,6 +319,10 @@ public class CctvService {
             log.warn("[CCTV] 권한 없는 사용자의 리뷰 시도: userId={}, matchId={}", userId, matchId);
             throw new ForbiddenException("해당 매칭 정보를 수정할 권한이 없습니다.");
         }
+        if (request.getReviewStatus() != DetectionReviewStatus.CONFIRMED_SELF
+                && request.getReviewStatus() != DetectionReviewStatus.REJECTED_SELF) {
+            throw new BadRequestException("유효하지 않은 리뷰 상태입니다.");
+        }
         if (cctvDetectionMatch.getReviewStatus() != DetectionReviewStatus.PENDING) {
             log.info("[CCTV] 이미 처리된 Detection입니다. matchId={}, Status={}", matchId, cctvDetectionMatch.getReviewStatus());
             return;

--- a/src/main/java/com/zoopick/server/service/CreateCctvMatchEventListner.java
+++ b/src/main/java/com/zoopick/server/service/CreateCctvMatchEventListner.java
@@ -22,7 +22,7 @@ public class CreateCctvMatchEventListner {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMatchCreated(CreateCctvMatchEvent event) {
-        Room room = event.cctvDetection().getCctvVideo().getRoom();
+        Room room = event.room();
         Item item = event.item();
         CctvDetectionMatch cctvDetectionMatch = event.cctvDetectionMatch();
         String title = event.itemPost().getTitle();

--- a/zoopick_dump.sql
+++ b/zoopick_dump.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict dJx3IgiugBwJZYMDWrR0US0pal6u35Hdm2fQbPsePO0N9aGn2WEodEMq8BSov0h
+\restrict d2PNngeVb8pLQVks9u88AsMEZ4EADLpzp5p5oM1BXpphFArhFN03khTuoKN2QR1
 
 -- Dumped from database version 18.3
 -- Dumped by pg_dump version 18.3
@@ -1225,6 +1225,7 @@ COPY zoopick.locker_commands (id, locker_id, command, status, issued_by, created
 --
 
 COPY zoopick.lockers (id, status, current_item_id) FROM stdin;
+1	EMPTY	\N
 \.
 
 
@@ -1667,27 +1668,6 @@ ALTER TABLE ONLY zoopick.users
 
 
 --
--- Name: idx_items_embedding_hnsw; Type: INDEX; Schema: zoopick; Owner: postgres
---
-
-CREATE INDEX idx_items_embedding_hnsw ON zoopick.items USING hnsw (embedding vector_cosine_ops);
-
-
---
--- Name: idx_detections_embedding_hnsw; Type: INDEX; Schema: zoopick; Owner: postgres
---
-
-CREATE INDEX idx_detections_embedding_hnsw ON zoopick.cctv_detections USING hnsw (embedding vector_cosine_ops);
-
-
---
--- Name: idx_items_filtering; Type: INDEX; Schema: zoopick; Owner: postgres
---
-
-CREATE INDEX idx_items_filtering ON zoopick.items (category, color);
-
-
---
 -- Name: idx_chatrooms_open; Type: INDEX; Schema: zoopick; Owner: postgres
 --
 
@@ -1697,7 +1677,6 @@ CREATE INDEX idx_chatrooms_open ON zoopick.chat_rooms USING btree (status) WHERE
 --
 -- Name: idx_commands_pending; Type: INDEX; Schema: zoopick; Owner: postgres
 --
-
 
 CREATE INDEX idx_commands_pending ON zoopick.locker_commands USING btree (locker_id, created_at) WHERE (status = 'PENDING'::zoopick.locker_command_status);
 
@@ -2061,4 +2040,5 @@ ALTER TABLE ONLY zoopick.cctv_videos
 -- PostgreSQL database dump complete
 --
 
-\unrestrict dJx3IgiugBwJZYMDWrR0US0pal6u35Hdm2fQbPsePO0N9aGn2WEodEMq8BSov0h
+\unrestrict d2PNngeVb8pLQVks9u88AsMEZ4EADLpzp5p5oM1BXpphFArhFN03khTuoKN2QR1
+


### PR DESCRIPTION
CCTV-분실물 AI 매칭 기능 및 매칭 리뷰 API가 추가되었습니다. 기능 구현 이후 테스트 과정에서 아래 3가지 버그가 발견되었으며, 이를 수정한걸 올립니다.  확인해주시면 감사하겠습니다

  ---
  변경 사항

  **1. CCTV 매칭 알림 발송 시 LazyInitializationException 수정**

  문제 원인

  CreateCctvMatchEventListner.handleMatchCreated()는 다음과 같이 선언되어 있습니다.

```java
  @Transactional(propagation = Propagation.REQUIRES_NEW)
  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
  public void handleMatchCreated(CreateCctvMatchEvent event) {
      Room room = event.cctvDetection().getCctvVideo().getRoom(); // 여기서 예외 발생
      ...
  }
```

  AFTER_COMMIT 페이즈는 이벤트를 발행한 원 트랜잭션이 커밋된 이후 실행됩니다. 이 시점에서 원 트랜잭션의 세션은 이미 닫혀 있고, 이벤트 객체에 담긴 CctvDetection은 detached 상태입니다.

  @Transactional(REQUIRES_NEW)로 새 트랜잭션이 열리지만, detached 상태의 엔티티는 새 세션에 자동으로 재연결(merge)되지 않습니다.
 따라서 getCctvVideo()(LAZY 연관관계) 접근 시 LazyInitializationException이 발생하고, CCTV 매칭 성사 시에 FCM 알림이 전송되지 않는 문제가 있었습니다.

  **수정했던 부분** 

  detached 엔티티에 접근하는 대신, 이벤트를 발행하는 트랜잭션이 열려 있는 동안 Room을 미리 로드하여 이벤트 객체에 포함시킵니다.

```java
  // CctvMatchService.java — 이벤트 발행 전 같은 트랜잭션 내에서 room 로드
  Room room = cctvDetection.getCctvVideo().getRoom();
  eventPublisher.publishEvent(new CreateCctvMatchEvent(lostItem, savedMatch, cctvDetection, itemPost, room));

  // CreateCctvMatchEventListner.java — detached 엔티티 접근 제거
  Room room = event.room(); // 이미 로드된 값 사용
```

  수정 파일

  - src/main/java/com/zoopick/server/dto/match/CreateCctvMatchEvent.java — Room room 필드 추가
  - src/main/java/com/zoopick/server/service/CctvMatchService.java — 이벤트 발행 2곳에서 room 미리 로드 후 전달 (matchDetectionToLostItems(), matchLostItemsToCctv())
  - src/main/java/com/zoopick/server/service/CreateCctvMatchEventListner.java — event.cctvDetection().getCctvVideo().getRoom() → event.room() 교체

  ---
  2. CCTV 리뷰 API 허용되지 않는 상태값 입력 검증 추가 (에러 처리, 기존 로직에 변경점 x)

  문제 원인

  PUT /api/cctv/detections/{matchId}/review 엔드포인트는 요청 바디의 review_status 필드로 DetectionReviewStatus enum 전체를 허용합니다. 이로 인해 클라이언트가 PENDING 또는 UNCERTAIN 같이 리뷰 응답으로 허용되지 않는 값을 전송해도
   서버가 이를 거부하지 않고 처리합니다.

  예를 들어 PENDING을 전송하면:
  1. cctvDetectionMatch.getReviewStatus() != PENDING 조건이 false → 통과
  2. 도난 처리 분기 미진입
  3. updateDetectionReviewStatus(PENDING) 실행 — 의도치 않은 상태 덮어쓰기 발생

  리뷰 API에서 클라이언트가 전송할 수 있는 값은 CONFIRMED_SELF(도난 의심 확인)와 REJECTED_SELF(아님) 두 가지뿐이어야 합니다.

  수정한 부분

  reviewMatch() 내부 시작 지점에 명시적 검증을 추가하여, 허용되지 않는 값이 들어오면 즉시 400 Bad Request를 반환합니다.

```java
  if (request.getReviewStatus() != DetectionReviewStatus.CONFIRMED_SELF
          && request.getReviewStatus() != DetectionReviewStatus.REJECTED_SELF) {
      throw new BadRequestException("유효하지 않은 리뷰 상태입니다.");
  }

```
  수정 파일

  - src/main/java/com/zoopick/server/service/CctvService.java

  ---
  **3.  CctvDetectionReviewRequest Jackson 역직렬화 안정성 개선** (기존 로직 변경 x)

  문제 원인

  CctvDetectionReviewRequest는 @Getter, @Setter, @AllArgsConstructor만 선언되어 있고 @NoArgsConstructor가 없습니다.

```java 
  @Getter
  @Setter
  @AllArgsConstructor
  public class CctvDetectionReviewRequest {
      @NotNull
      @JsonProperty("review_status")
      DetectionReviewStatus reviewStatus;
  }

```
  Jackson은 기본적으로 역직렬화 시 기본 생성자(no-args constructor) 를 통해 객체를 생성한 뒤 setter로 값을 주입합니다. 기본 생성자가 없으면 Jackson은 대안으로 생성자 파라미터 이름 매핑을 시도하는데, Lombok의
  @AllArgsConstructor는 필드에 선언된 @JsonProperty("review_status")를 생성자 파라미터에 복사하지 않습니다. 따라서 Spring Boot의 ParameterNamesModule이 있어도 JSON 필드명 review_status와 파라미터 이름 reviewStatus의 불일치로    
  역직렬화 실패 가능성이 있습니다.

  수정한 방법 

  @NoArgsConstructor를 추가하여 Jackson이 안정적으로 객체를 생성할 수 있도록 합니다.
```java

  @Getter
  @Setter
  @NoArgsConstructor
  @AllArgsConstructor
  public class CctvDetectionReviewRequest { ... }

```
  수정 파일

  - src/main/java/com/zoopick/server/dto/cctv/CctvDetectionReviewRequest.java

  ---
  테스트 방법

 1번의 경우:  FCM 알림 발송 확인
  - CCTV 분석 완료 후 매칭이 생성될 때 서버 로그에서 FCM 전송 성공 matchId: {} 출력 확인
  - 이전에는 LazyInitializationException으로 인해 해당 로그가 찍히지 않았음

  2번:  리뷰 API 입력 검증 확인

 
 "CONFIRMED_SELF"   200 OK + 해당 분실물 도난 의심 상태로 변경 │
"REJECTED_SELF"        200 OK                        
"PENDING"                 400 Bad Request                   
 "UNCERTAIN"            400 Bad Request                       
 

3번: 역직렬화 확인
  - 위 이슈 2 테스트와 동일하게 리뷰 API 정상 동작 여부로 확인


추가로 ddl에 공통적으로 써야 할 락커 컬럼이 없기에 locker.id=1  1번 락커 추가해서 올렸습니다 