### PR TITLE
Feat: 나의 분실물 습득물 api

### DIFF
--- a/src/main/java/com/zoopick/server/controller/ItemPostController.java
+++ b/src/main/java/com/zoopick/server/controller/ItemPostController.java
@@ -2,6 +2,7 @@ package com.zoopick.server.controller;
 
 import com.zoopick.server.dto.CommonResponse;
 import com.zoopick.server.dto.item.*;
+import com.zoopick.server.entity.ItemType;
 import com.zoopick.server.security.UserPrincipal;
 import com.zoopick.server.service.ItemPostService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,6 +16,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import java.util.List;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -75,6 +77,21 @@ public class ItemPostController {
             @PathVariable long id
     ) {
         ItemPostRecord result = itemPostService.getItemPost(id);
+        return ResponseEntity.ok(CommonResponse.success(result));
+    }
+
+    @Operation(summary = "내 게시글 목록 조회", description = "현재 로그인한 사용자가 등록한 분실물(LOST) 또는 습득물(FOUND) 게시글 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    @GetMapping("/me")
+    public ResponseEntity<CommonResponse<List<ItemPostRecord>>> getMyItemPosts(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Parameter(description = "조회할 게시글 타입 (LOST 또는 FOUND)", example = "LOST")
+            @RequestParam ItemType type
+    ) {
+        List<ItemPostRecord> result = itemPostService.getMyItemPosts(principal.id(), type);
         return ResponseEntity.ok(CommonResponse.success(result));
     }
 

--- a/src/main/java/com/zoopick/server/repository/ItemPostRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ItemPostRepository.java
@@ -59,4 +59,6 @@ public interface ItemPostRepository extends JpaRepository<ItemPost, Long>, JpaSp
 
     @Query("SELECT ip FROM ItemPost ip JOIN FETCH ip.item WHERE ip.item.id IN :itemIds")
     List<ItemPost> findAllByItemIdsWithItem(@Param("itemIds") List<Long> itemIds);
+
+    List<ItemPost> findAllByUser_IdAndItem_Type(Long userId, ItemType type);
 }

--- a/src/main/java/com/zoopick/server/service/ItemPostService.java
+++ b/src/main/java/com/zoopick/server/service/ItemPostService.java
@@ -73,6 +73,12 @@ public class ItemPostService {
         return itemPostMapper.toItemPostRecord(itemPost);
     }
 
+    public List<ItemPostRecord> getMyItemPosts(long userId, ItemType type) {
+        return itemPostRepository.findAllByUser_IdAndItem_Type(userId, type).stream()
+                .map(itemPostMapper::toItemPostRecord)
+                .toList();
+    }
+
     public ItemOwnerInfoResult getOwnerInfo(long userId, long itemId) {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> DataNotFoundException.from("물품", itemId));


### PR DESCRIPTION
 ## 개요
마이 페이지 연동 내 분실물
  ## 변경 사항

  - `GET /api/items/me?type=LOST` — 내 분실물 목록 반환
  - `GET /api/items/me?type=FOUND` — 내 습득물 목록 반환

  ## 수정 파일

  - `ItemPostRepository` — `findAllByUser_IdAndItem_Type` 쿼리 메서드 추가
  - `ItemPostService` — `getMyItemPosts(userId, type)` 메서드 추가
  - `ItemPostController` — `GET /api/items/me` 엔드포인트 추가

  ## 응답 예시

  GET /api/items/me?type=LOST

```json
  {
    "data": [
      {
        "id": 1,
        "title": "검은색 지갑 잃어버렸어요",
        "type": "LOST",
        "status": "REPORTED",
        "category": "WALLET",
        "reporter_id": 42,
        ...
      }
    ],
    "success": true
  }

```
  ## 관련 이슈

  - 프론트 lost-item-detail.tsx 수동 매칭 버튼 구현 시 이 API로 lost_item_id 조회 후 사용
