### PR TITLE
Fix: 채팅방 버그 수정 (거래 완료 미반영, 방 중복 재사용, Firebase 초기화) 

### DIFF
--- a/src/main/java/com/zoopick/server/config/FirebaseConfig.java
+++ b/src/main/java/com/zoopick/server/config/FirebaseConfig.java
@@ -24,7 +24,9 @@ public class FirebaseConfig {
                     .setCredentials(GoogleCredentials.fromStream(serviceAccount))
                     .build();
 
-            FirebaseApp.initializeApp(options);
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+            }
         } catch (IOException exception) {
             log.error(exception.getMessage(), exception);
         }

--- a/src/main/java/com/zoopick/server/entity/ChatRoom.java
+++ b/src/main/java/com/zoopick/server/entity/ChatRoom.java
@@ -49,6 +49,11 @@ public class ChatRoom {
     @Builder.Default
     private ChatRoomStatus status = ChatRoomStatus.OPEN;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
+    @JoinColumn(name = "resolved_by")
+    private User resolvedBy;
+
     @Column(name = "resolved_at")
     private LocalDateTime resolvedAt;
 

--- a/src/main/java/com/zoopick/server/repository/ChatRoomRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ChatRoomRepository.java
@@ -4,6 +4,8 @@ import com.zoopick.server.entity.ChatRoom;
 import com.zoopick.server.entity.ChatRoomStatus;
 import com.zoopick.server.exception.DataNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -21,11 +23,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
         return findByOwnerIdOrFinderId(userId, userId);
     }
 
-    Optional<ChatRoom> findByOwnerIdOrFinderIdAndItemIdIs(long ownerId, long finderId, long itemId);
-
-    default Optional<ChatRoom> findByParticipantIdAndItemIdIs(long userId, long itemId) {
-        return findByOwnerIdOrFinderIdAndItemIdIs(userId, userId, itemId);
-    }
+    @Query("SELECT cr FROM ChatRoom cr WHERE (cr.owner.id = :userId OR cr.finder.id = :userId) AND cr.item.id = :itemId AND cr.status = 'OPEN'")
+    Optional<ChatRoom> findOpenByParticipantAndItem(@Param("userId") long userId, @Param("itemId") long itemId);
 
     long countByOwnerIdOrFinderId(Long ownerId, Long finderId);
 

--- a/src/main/java/com/zoopick/server/repository/ChatRoomRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ChatRoomRepository.java
@@ -1,6 +1,7 @@
 package com.zoopick.server.repository;
 
 import com.zoopick.server.entity.ChatRoom;
+import com.zoopick.server.entity.ChatRoomStatus;
 import com.zoopick.server.exception.DataNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -29,4 +30,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     long countByOwnerIdOrFinderId(Long ownerId, Long finderId);
 
     Optional<ChatRoom> findByOwnerIdAndFinderIdIs(long ownerId, long finderId);
+
+    Optional<ChatRoom> findByOwnerIdAndFinderIdIsAndStatus(long ownerId, long finderId, ChatRoomStatus status);
 }

--- a/src/main/java/com/zoopick/server/service/ChatRoomService.java
+++ b/src/main/java/com/zoopick/server/service/ChatRoomService.java
@@ -47,8 +47,11 @@ public class ChatRoomService {
 
         Optional<ChatRoom> existingChatRoom = chatRoomRepository.findByParticipantIdAndItemIdIs(requesterId, itemId);
         if (existingChatRoom.isPresent()) {
-            existingChatRoom.get().setStatus(ChatRoomStatus.OPEN);
-            return new CreateChatRoomResult(false, chatRoomMapper.toChatRoomRecord(existingChatRoom.get()));
+            ChatRoom existing = existingChatRoom.get();
+            existing.setStatus(ChatRoomStatus.OPEN);
+            existing.setResolvedBy(null);
+            existing.setResolvedAt(null);
+            return new CreateChatRoomResult(false, chatRoomMapper.toChatRoomRecord(existing));
         }
 
         ChatRoom chatRoom = ChatRoom.builder()
@@ -64,9 +67,8 @@ public class ChatRoomService {
         User requester = userRepository.findByIdOrThrow(requesterId);
         User owner = userRepository.findByIdOrThrow(ownerId);
 
-        Optional<ChatRoom> existingChatRoom = chatRoomRepository.findByOwnerIdAndFinderIdIs(ownerId, requesterId);
+        Optional<ChatRoom> existingChatRoom = chatRoomRepository.findByOwnerIdAndFinderIdIsAndStatus(ownerId, requesterId, ChatRoomStatus.OPEN);
         if (existingChatRoom.isPresent()) {
-            existingChatRoom.get().setStatus(ChatRoomStatus.OPEN);
             return new CreateChatRoomResult(false, chatRoomMapper.toChatRoomRecord(existingChatRoom.get()));
         }
 
@@ -229,6 +231,7 @@ public class ChatRoomService {
             throw new BadRequestException("이미 닫힌 채팅방입니다.", chatRoomId + " is already closed.");
 
         chatRoom.setStatus(reason.toChatRoomStatus());
+        chatRoom.setResolvedBy(sender);
         chatRoom.setResolvedAt(LocalDateTime.now());
         chatRoomRepository.save(chatRoom);
 
@@ -257,6 +260,7 @@ public class ChatRoomService {
             throw new BadRequestException("이미 열린 채팅방입니다.", chatRoomId + " is already opened.");
 
         chatRoom.setStatus(ChatRoomStatus.OPEN);
+        chatRoom.setResolvedBy(null);
         chatRoom.setResolvedAt(null);
         chatRoomRepository.save(chatRoom);
 

--- a/src/main/java/com/zoopick/server/service/ChatRoomService.java
+++ b/src/main/java/com/zoopick/server/service/ChatRoomService.java
@@ -113,7 +113,7 @@ public class ChatRoomService {
     }
 
     public FindChatRoomResult findChatRoom(long userId, long itemId) {
-        Optional<Long> chatRoomId = chatRoomRepository.findByParticipantIdAndItemIdIs(userId, itemId)
+        Optional<Long> chatRoomId = chatRoomRepository.findOpenByParticipantAndItem(userId, itemId)
                 .map(ChatRoom::getId);
 
         return new FindChatRoomResult(chatRoomId.isPresent(), chatRoomId.orElse(0L));

--- a/src/main/java/com/zoopick/server/service/ChatRoomService.java
+++ b/src/main/java/com/zoopick/server/service/ChatRoomService.java
@@ -45,13 +45,9 @@ public class ChatRoomService {
         User requester = userRepository.findByIdOrThrow(requesterId);
         User counterpart = userRepository.findByIdOrThrow(createChatRoomRequest.getCounterpartId());
 
-        Optional<ChatRoom> existingChatRoom = chatRoomRepository.findByParticipantIdAndItemIdIs(requesterId, itemId);
+        Optional<ChatRoom> existingChatRoom = chatRoomRepository.findOpenByParticipantAndItem(requesterId, itemId);
         if (existingChatRoom.isPresent()) {
-            ChatRoom existing = existingChatRoom.get();
-            existing.setStatus(ChatRoomStatus.OPEN);
-            existing.setResolvedBy(null);
-            existing.setResolvedAt(null);
-            return new CreateChatRoomResult(false, chatRoomMapper.toChatRoomRecord(existing));
+            return new CreateChatRoomResult(false, chatRoomMapper.toChatRoomRecord(existingChatRoom.get()));
         }
 
         ChatRoom chatRoom = ChatRoom.builder()

--- a/src/main/java/com/zoopick/server/service/ChatRoomService.java
+++ b/src/main/java/com/zoopick/server/service/ChatRoomService.java
@@ -232,6 +232,10 @@ public class ChatRoomService {
         chatRoom.setResolvedAt(LocalDateTime.now());
         chatRoomRepository.save(chatRoom);
 
+        if (reason == ChatRoomCloseReason.RETURNED && chatRoom.getItem() != null) {
+            chatRoom.getItem().setStatus(ItemStatus.RETURNED);
+        }
+
         SendNotificationCommand command = new SendNotificationCommand(
                 "Zoopick",
                 "채팅방이 닫혔습니다.",


### PR DESCRIPTION
 ## 개요

  채팅 기능에서 발생하던 세 가지 버그를 수정합니다.

  ## 수정 내용

  ### 1. 거래 완료 시 item.status 미갱신
  PATCH /api/chat-rooms/:id/close (reason=RETURNED) 호출 시
  ChatRoom.status는 RESOLVED_RETURNED로 바뀌었지만
  연결된 Item.status가 RETURNED로 바뀌지 않던 문제 수정.

  - ChatRoomService.closeChatRoom — reason=RETURNED이고 item != null이면
    item.setStatus(RETURNED) 추가

  ### 2. 두 사람이 새 물건으로 만날 때 이전 채팅방 재사용
  두 가지 버그가 복합적으로 작용.

  (1) JPA 파생 쿼리 우선순위 버그
  findByOwnerIdOrFinderIdAndItemIdIs가 의도와 다르게 해석됨.
    - 의도: (owner_id = ? OR finder_id = ?) AND item_id = ?
    - 실제: owner_id = ? OR (finder_id = ? AND item_id = ?)
  → @Query로 교체하여 올바른 우선순위 적용 + status = OPEN 조건 추가

  (2) createChatRoomByOwner가 종료된 방 재오픈
  item 없이 두 사람 사이 방을 검색할 때 RESOLVED 상태 방도 반환하여
  강제로 OPEN으로 되돌리던 문제.
  → findByOwnerIdAndFinderIdIsAndStatus(..., OPEN)으로 교체,
    RESOLVED 상태면 새 방 생성

  ### 3. Firebase 중복 초기화 오류
  DevTools 핫 리로드 시 FirebaseApp이 이미 초기화된 상태에서
  initializeApp()을 재호출하여 애플리케이션이 기동 실패하던 문제.
  → FirebaseApp.getApps().isEmpty() 체크 추가

  ## 수정 파일

  - FirebaseConfig.java
  - ChatRoom.java — resolved_by 필드 추가 (DB 제약 조건 chk_chatrooms_resolved 충족)
  - ChatRoomRepository.java
  - ChatRoomService.java


<img width="1072" height="99" alt="스크린샷 2026-05-17 214141" src="https://github.com/user-attachments/assets/ffa0d92c-0017-4cf7-8ccc-d2a0ed53828f" />
<img width="1085" height="161" alt="스크린샷 2026-05-17 224946" src="https://github.com/user-attachments/assets/1c67b21d-190e-4112-8ef4-9ad6fb0f0647" />
<img width="1073" height="164" alt="스크린샷 2026-05-17 230918" src="https://github.com/user-attachments/assets/7825a800-ea66-46d9-abbc-296c54a424c0" />
