### PR TITLE
 Feat: 게시판 역방향 조회 → 채팅 합의 → 사물함 수령 플로우 구현

### DIFF
--- a/src/main/java/com/zoopick/server/repository/ChatRoomRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ChatRoomRepository.java
@@ -2,6 +2,7 @@ package com.zoopick.server.repository;
 
 import com.zoopick.server.entity.ChatRoom;
 import com.zoopick.server.entity.ChatRoomStatus;
+import com.zoopick.server.entity.Item;
 import com.zoopick.server.exception.DataNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -31,4 +32,9 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     Optional<ChatRoom> findByOwnerIdAndFinderIdIs(long ownerId, long finderId);
 
     Optional<ChatRoom> findByOwnerIdAndFinderIdIsAndStatus(long ownerId, long finderId, ChatRoomStatus status);
+
+    boolean existsByItemAndOwnerId(Item item, long ownerId);
+
+    @Query("SELECT cr FROM ChatRoom cr WHERE (cr.owner.id = :userId OR cr.finder.id = :userId) AND cr.item.id = :itemId")
+    Optional<ChatRoom> findByParticipantAndItem(@Param("userId") long userId, @Param("itemId") long itemId);
 }

--- a/src/main/java/com/zoopick/server/repository/ChatRoomRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ChatRoomRepository.java
@@ -35,6 +35,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     boolean existsByItemAndOwnerId(Item item, long ownerId);
 
+    boolean existsByItemAndOwnerIdAndStatus(Item item, long ownerId, ChatRoomStatus status);
+
     @Query("SELECT cr FROM ChatRoom cr WHERE (cr.owner.id = :userId OR cr.finder.id = :userId) AND cr.item.id = :itemId")
     Optional<ChatRoom> findByParticipantAndItem(@Param("userId") long userId, @Param("itemId") long itemId);
 }

--- a/src/main/java/com/zoopick/server/security/JwtUtil.java
+++ b/src/main/java/com/zoopick/server/security/JwtUtil.java
@@ -17,7 +17,7 @@ import java.util.Date;
 @NullMarked
 public class JwtUtil {
     // 토큰 만료 시간 1일
-    private static final long EXPIRATION_TIME = 1000 * 60 * 60 * 24;
+    private static final long EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 7;
 
     private final SecretKey secretKey;
 

--- a/src/main/java/com/zoopick/server/service/ChatRoomService.java
+++ b/src/main/java/com/zoopick/server/service/ChatRoomService.java
@@ -231,7 +231,9 @@ public class ChatRoomService {
         chatRoom.setResolvedAt(LocalDateTime.now());
         chatRoomRepository.save(chatRoom);
 
-        if (reason == ChatRoomCloseReason.RETURNED && chatRoom.getItem() != null) {
+        // 사물함에 있는 물건은 handleRetrieval에서 RETURNED 처리 (여기서 조기 변경 금지)
+        if (reason == ChatRoomCloseReason.RETURNED && chatRoom.getItem() != null
+                && chatRoom.getItem().getStatus() != ItemStatus.IN_LOCKER) {
             chatRoom.getItem().setStatus(ItemStatus.RETURNED);
         }
 

--- a/src/main/java/com/zoopick/server/service/LockerService.java
+++ b/src/main/java/com/zoopick/server/service/LockerService.java
@@ -23,6 +23,7 @@ public class LockerService {
     private final ItemRepository itemRepository;
     private final UserRepository userRepository;
     private final ItemMatchRepository itemMatchRepository;
+    private final ChatRoomRepository chatRoomRepository;
 
     @Transactional
     public LockerCommand requestUnlock(Long userId, Long lockerId, Long itemId) {
@@ -87,12 +88,13 @@ public class LockerService {
     private void handleRetrieval(Long userId, Locker locker) {
         Item stored = locker.getCurrentItem();
 
-        //권한 확인: 신고자 본인이거나, CONFIRMED 매칭된 소유자여야 함
+        //권한 확인: 신고자 본인이거나, CONFIRMED 매칭된 소유자이거나, 채팅으로 합의한 분실자여야 함
         boolean isReporter = stored.getReporter().getId().equals(userId);
         boolean isMatchedOwner = itemMatchRepository.existsByFoundItemAndLostItem_Reporter_IdAndStatus(
                 stored, userId, MatchStatus.CONFIRMED);
+        boolean isChatOwner = chatRoomRepository.existsByItemAndOwnerId(stored, userId);
 
-        if (!isReporter && !isMatchedOwner) {
+        if (!isReporter && !isMatchedOwner && !isChatOwner) {
             throw new ForbiddenException(
                     "물품을 회수할 권한이 없습니다.",
                     "User " + userId + " has no permission to retrieve item " + stored.getId());

--- a/src/main/java/com/zoopick/server/service/LockerService.java
+++ b/src/main/java/com/zoopick/server/service/LockerService.java
@@ -88,13 +88,12 @@ public class LockerService {
     private void handleRetrieval(Long userId, Locker locker) {
         Item stored = locker.getCurrentItem();
 
-        //권한 확인: 신고자 본인이거나, CONFIRMED 매칭된 소유자이거나, 채팅으로 합의한 분실자여야 함
-        boolean isReporter = stored.getReporter().getId().equals(userId);
+        //권한 확인: AI 매칭 CONFIRMED 소유자이거나, 채팅 RESOLVED_RETURNED된 분실자여야 함
         boolean isMatchedOwner = itemMatchRepository.existsByFoundItemAndLostItem_Reporter_IdAndStatus(
                 stored, userId, MatchStatus.CONFIRMED);
         boolean isChatOwner = chatRoomRepository.existsByItemAndOwnerIdAndStatus(stored, userId, ChatRoomStatus.RESOLVED_RETURNED);
 
-        if (!isReporter && !isMatchedOwner && !isChatOwner) {
+        if (!isMatchedOwner && !isChatOwner) {
             throw new ForbiddenException(
                     "물품을 회수할 권한이 없습니다.",
                     "User " + userId + " has no permission to retrieve item " + stored.getId());

--- a/src/main/java/com/zoopick/server/service/LockerService.java
+++ b/src/main/java/com/zoopick/server/service/LockerService.java
@@ -92,7 +92,7 @@ public class LockerService {
         boolean isReporter = stored.getReporter().getId().equals(userId);
         boolean isMatchedOwner = itemMatchRepository.existsByFoundItemAndLostItem_Reporter_IdAndStatus(
                 stored, userId, MatchStatus.CONFIRMED);
-        boolean isChatOwner = chatRoomRepository.existsByItemAndOwnerId(stored, userId);
+        boolean isChatOwner = chatRoomRepository.existsByItemAndOwnerIdAndStatus(stored, userId, ChatRoomStatus.RESOLVED_RETURNED);
 
         if (!isReporter && !isMatchedOwner && !isChatOwner) {
             throw new ForbiddenException(


### PR DESCRIPTION
플로우

 [습득자] FOUND 게시글 등록 → 사물함 QR 스캔 → 물건 보관 (item.status = IN_LOCKER)
 [분실자] 게시판 탐색 → FOUND 게시글 발견 → 채팅 시작
        → 대화로 소유 확인 → "수령 완료" 버튼 (채팅방 close, reason=RETURNED)
        → 사물함 QR 스캔 → 물건 수령 (item.status = RETURNED)

 변경 사항

 ChatRoomRepository.java
 - existsByItemAndOwnerId 추가 — 해당 아이템에 대해 owner로 채팅방을 연 사람 확인
 - existsByItemAndOwnerIdAndStatus 추가 — 채팅방 상태(RESOLVED_RETURNED) 포함 인가 확인
 - findByParticipantAndItem 추가 — 상태 무관 참여자+아이템 조회

 LockerService.java
 - ChatRoomRepository 의존성 추가
 - handleRetrieval 권한 체크 수정:
   - 기존: 습득자(isReporter) OR AI매칭 소유자 OR 채팅 소유자
   - 변경: AI매칭 소유자(isMatchedOwner) OR 채팅 RESOLVED_RETURNED 소유자(isChatOwner)
   - 이유: 사물함에 물건을 넣은 습득자가 다시 꺼낼 수 없도록 제한

 ChatRoomService.java
 - closeChatRoom 버그 수정: item이 IN_LOCKER 상태일 때 채팅방 close(RETURNED)가
 item.status를 조기에 RETURNED로 변경하던 문제 수정
 → 사물함에 있는 물건은 실제 QR 스캔(handleRetrieval) 시에만 RETURNED로 변경

 프론트 연동 API 순서

 1. POST /api/chat-rooms — item_id + counterpart_id 필수 포함
 2. PATCH /api/chat-rooms/:id/close — body: { "reason": "RETURNED" }
 3. POST /api/lockers/1/unlock — body: {} (empty, 회수 분기)

 권한 규칙
 - "수령 완료" 버튼 누르기 전 QR 스캔 → 403
 - 채팅방 없는 제3자 QR 스캔 → 403
 - AI 매칭(ItemMatch.CONFIRMED) 경로 → 기존과 동일하게 동작
<img width="1071" height="388" alt="스크린샷 2026-05-18 032108" src="https://github.com/user-attachments/assets/5b39eb46-868e-475c-adda-03e9318a2e4d" />