### PR TITLE
Refactor: 매칭 이벤트 배치 발행 및 리스너 N+1 제거

### DIFF
--- a/src/main/java/com/zoopick/server/dto/match/CreateCctvMatchEvent.java
+++ b/src/main/java/com/zoopick/server/dto/match/CreateCctvMatchEvent.java
@@ -1,10 +1,23 @@
 package com.zoopick.server.dto.match;
 
-import com.zoopick.server.entity.CctvDetection;
-import com.zoopick.server.entity.CctvDetectionMatch;
-import com.zoopick.server.entity.Item;
-import com.zoopick.server.entity.ItemPost;
-import com.zoopick.server.entity.Room;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
-public record CreateCctvMatchEvent(Item item, CctvDetectionMatch cctvDetectionMatch, CctvDetection cctvDetection, ItemPost itemPost, Room room) {
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CreateCctvMatchEvent {
+    private final List<Entry> entries;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Entry {
+        private final long matchId;
+        private final float score;
+        private final long lostItemId;
+        private final long reporterUserId;
+        private final String itemPostTitle;
+        private final String roomName;
+    }
 }

--- a/src/main/java/com/zoopick/server/dto/match/CreateMatchEvent.java
+++ b/src/main/java/com/zoopick/server/dto/match/CreateMatchEvent.java
@@ -1,6 +1,23 @@
 package com.zoopick.server.dto.match;
 
-import com.zoopick.server.entity.Item;
-import com.zoopick.server.entity.ItemMatch;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
-public record CreateMatchEvent(ItemMatch match, Item lostItem, Item foundItem) {}
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CreateMatchEvent {
+    private final List<Entry> entries;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Entry {
+        private final long matchId;
+        private final float score;
+        private final long lostItemId;
+        private final long reporterUserId;
+        private final String itemPostTitle;
+        private final String foundLocationName;
+    }
+}

--- a/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ItemMatchRepository.java
@@ -89,6 +89,11 @@ public interface ItemMatchRepository extends JpaRepository<ItemMatch, Long> {
                                 @Param("lostItemId") Long lostItemId,
                                 @Param("foundItemId") Long foundItemId);
 
+    // 알림 발송 후 매칭 상태를 NOTIFIED로 일괄 갱신
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE ItemMatch m SET m.status = :status WHERE m.id IN :ids")
+    void updateStatusInBatch(@Param("ids") List<Long> ids, @Param("status") MatchStatus status);
+
     // CONFIRMED된 매칭이 있는지 확인
     boolean existsByLostItemAndStatus(Item lostItem, MatchStatus status);
 

--- a/src/main/java/com/zoopick/server/service/CctvMatchService.java
+++ b/src/main/java/com/zoopick/server/service/CctvMatchService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -67,6 +68,7 @@ public class CctvMatchService {
                         post -> post));
 
         Room detectionRoom = cctvDetection.getCctvVideo().getRoom();
+        List<CreateCctvMatchEvent.Entry> entries = new ArrayList<>();
 
         for (SimilarItemResult s : similarItems) {
             ItemPost itemPost = itemPostMap.get(s.getItemId());
@@ -93,9 +95,18 @@ public class CctvMatchService {
                         .cctvDetection(cctvDetection)
                         .build());
                 log.info("CCTV 매칭된 아이템 ID: {}", lostItem.getId());
-                Room room = cctvDetection.getCctvVideo().getRoom();
-                eventPublisher.publishEvent(new CreateCctvMatchEvent(lostItem, savedMatch, cctvDetection, itemPost, room));
+                entries.add(new CreateCctvMatchEvent.Entry(
+                        savedMatch.getId(),
+                        savedMatch.getScore(),
+                        lostItem.getId(),
+                        lostItem.getReporter().getId(),
+                        itemPost.getTitle(),
+                        detectionRoom.getName()));
             }
+        }
+
+        if (!entries.isEmpty()) {
+            eventPublisher.publishEvent(new CreateCctvMatchEvent(entries));
         }
         log.info("[CCTV] 매칭 종료 ID: {}", detectionId);
     }
@@ -134,6 +145,8 @@ public class CctvMatchService {
                 .stream()
                 .collect(Collectors.toMap(CctvDetection::getId, i -> i));
 
+        List<CreateCctvMatchEvent.Entry> entries = new ArrayList<>();
+
         for (SimilarItemResult s : similarItems) {
             CctvDetection foundItemInDb = detectionMap.get(s.getItemId());
             if (foundItemInDb == null)
@@ -148,9 +161,18 @@ public class CctvMatchService {
                         .build());
                 log.info("[CCTV] 매칭된 Detection ID: {}", foundItemInDb.getId());
                 Room foundRoom = foundItemInDb.getCctvVideo().getRoom();
-                eventPublisher
-                        .publishEvent(new CreateCctvMatchEvent(lostItem, savedMatch, foundItemInDb, lostItemPost, foundRoom));
+                entries.add(new CreateCctvMatchEvent.Entry(
+                        savedMatch.getId(),
+                        savedMatch.getScore(),
+                        lostItem.getId(),
+                        lostItem.getReporter().getId(),
+                        lostItemPost.getTitle(),
+                        foundRoom.getName()));
             }
+        }
+
+        if (!entries.isEmpty()) {
+            eventPublisher.publishEvent(new CreateCctvMatchEvent(entries));
         }
         log.info("[CCTV] 매칭 종료 ID: {}", lostItemId);
     }

--- a/src/main/java/com/zoopick/server/service/CreateCctvMatchEventListner.java
+++ b/src/main/java/com/zoopick/server/service/CreateCctvMatchEventListner.java
@@ -1,7 +1,8 @@
 package com.zoopick.server.service;
 
 import com.zoopick.server.dto.match.CreateCctvMatchEvent;
-import com.zoopick.server.entity.*;
+import com.zoopick.server.entity.User;
+import com.zoopick.server.repository.UserRepository;
 import com.zoopick.server.service.notification.NotificationService;
 import com.zoopick.server.service.notification.SendNotificationCommand;
 import com.zoopick.server.service.notification.payload.CctvFoundPayload;
@@ -13,24 +14,41 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class CreateCctvMatchEventListner {
     private final NotificationService notificationService;
+    private final UserRepository userRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMatchCreated(CreateCctvMatchEvent event) {
-        Room room = event.room();
-        Item item = event.item();
-        CctvDetectionMatch cctvDetectionMatch = event.cctvDetectionMatch();
-        String title = event.itemPost().getTitle();
+        List<CreateCctvMatchEvent.Entry> entries = event.getEntries();
+        if (entries.isEmpty()) return;
 
-        notificationService.send(event.item().getReporter(), new SendNotificationCommand(
-                "도난 의심",
-                "회원님이 등록한 %s와 유사한 물건이 %s에서 도난이 의심돼요.".formatted(title, room.getName()),
-                CctvFoundPayload.of(item, cctvDetectionMatch)));
-        log.info("FCM 전송 성공 matchId: {}", cctvDetectionMatch.getId());
+        List<Long> reporterIds = entries.stream()
+                .map(CreateCctvMatchEvent.Entry::getReporterUserId)
+                .distinct()
+                .toList();
+        Map<Long, User> reporterMap = userRepository.findAllById(reporterIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        for (CreateCctvMatchEvent.Entry entry : entries) {
+            User reporter = reporterMap.get(entry.getReporterUserId());
+            if (reporter == null) continue;
+
+            notificationService.send(reporter, new SendNotificationCommand(
+                    "도난 의심",
+                    "회원님이 등록한 %s와 유사한 물건이 %s에서 도난이 의심돼요."
+                            .formatted(entry.getItemPostTitle(), entry.getRoomName()),
+                    new CctvFoundPayload(entry.getLostItemId(), entry.getMatchId(), entry.getScore())));
+            log.info("FCM 전송 성공 matchId: {}", entry.getMatchId());
+        }
     }
 }

--- a/src/main/java/com/zoopick/server/service/CreateMatchEventListner.java
+++ b/src/main/java/com/zoopick/server/service/CreateMatchEventListner.java
@@ -1,10 +1,10 @@
 package com.zoopick.server.service;
 
 import com.zoopick.server.dto.match.CreateMatchEvent;
-import com.zoopick.server.entity.Item;
-import com.zoopick.server.entity.ItemMatch;
 import com.zoopick.server.entity.MatchStatus;
-import com.zoopick.server.repository.ItemPostRepository;
+import com.zoopick.server.entity.User;
+import com.zoopick.server.repository.ItemMatchRepository;
+import com.zoopick.server.repository.UserRepository;
 import com.zoopick.server.service.notification.NotificationService;
 import com.zoopick.server.service.notification.SendNotificationCommand;
 import com.zoopick.server.service.notification.payload.MatchFoundPayload;
@@ -16,26 +16,47 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class CreateMatchEventListner {
     private final NotificationService notificationService;
-    private final ItemPostRepository itemPostRepository;
+    private final ItemMatchRepository itemMatchRepository;
+    private final UserRepository userRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMatchCreated(CreateMatchEvent event) {
-        ItemMatch match = event.match();
-        Item lostItem = event.lostItem();
-        Item foundItem = event.foundItem();
-        String title = itemPostRepository.findByItem(lostItem).getTitle();
-        String location = foundItem.getLocationName();
-        notificationService.send(lostItem.getReporter(), new SendNotificationCommand(
-                "분실물 발견",
-                "회원님이 등록한 %s와 유사한 물건이 %s에서 발견됐어요.".formatted(title, location),
-                MatchFoundPayload.of(lostItem, match)));
-        match.setStatus(MatchStatus.NOTIFIED);
-        log.info("FCM 전송 성공 matchId: {}", match.getId());
+        List<CreateMatchEvent.Entry> entries = event.getEntries();
+        if (entries.isEmpty()) return;
+
+        List<Long> reporterIds = entries.stream()
+                .map(CreateMatchEvent.Entry::getReporterUserId)
+                .distinct()
+                .toList();
+        Map<Long, User> reporterMap = userRepository.findAllById(reporterIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        for (CreateMatchEvent.Entry entry : entries) {
+            User reporter = reporterMap.get(entry.getReporterUserId());
+            if (reporter == null) continue;
+
+            notificationService.send(reporter, new SendNotificationCommand(
+                    "분실물 발견",
+                    "회원님이 등록한 %s와 유사한 물건이 %s에서 발견됐어요."
+                            .formatted(entry.getItemPostTitle(), entry.getFoundLocationName()),
+                    new MatchFoundPayload(entry.getLostItemId(), entry.getMatchId(), entry.getScore())));
+            log.info("FCM 전송 성공 matchId: {}", entry.getMatchId());
+        }
+
+        List<Long> matchIds = entries.stream()
+                .map(CreateMatchEvent.Entry::getMatchId)
+                .toList();
+        itemMatchRepository.updateStatusInBatch(matchIds, MatchStatus.NOTIFIED);
     }
 }

--- a/src/main/java/com/zoopick/server/service/ItemMatchService.java
+++ b/src/main/java/com/zoopick/server/service/ItemMatchService.java
@@ -5,6 +5,7 @@ import com.zoopick.server.dto.match.*;
 import com.zoopick.server.entity.*;
 import com.zoopick.server.exception.BadRequestException;
 import com.zoopick.server.repository.ItemMatchRepository;
+import com.zoopick.server.repository.ItemPostRepository;
 import com.zoopick.server.repository.ItemRepository;
 import com.zoopick.server.repository.LockerRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +15,9 @@ import org.springframework.data.domain.Vector;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -25,6 +28,7 @@ import java.util.stream.Collectors;
 public class ItemMatchService {
     private final ItemRepository itemRepository;
     private final ItemMatchRepository itemMatchRepository;
+    private final ItemPostRepository itemPostRepository;
     private final LockerRepository lockerRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final MatchConfig matchConfig;
@@ -65,6 +69,9 @@ public class ItemMatchService {
                 .limit(5)
                 .toList();
 
+        List<CreateMatchEvent.Entry> entries = new ArrayList<>();
+        Map<Long, String> titleCache = new HashMap<>();
+
         for (SimilarItemResult s : top5) {
             Item foundItemInDb = itemMap.get(s.getItemId());
             // 게시글에 올라온 아이템이 LOST라면 lostItem에, FOUND라면 foundItem에
@@ -80,8 +87,21 @@ public class ItemMatchService {
                         .status(MatchStatus.CANDIDATE)
                         .build());
                 log.info("매칭된 아이템 ID: {}", foundItemInDb.getId());
-                eventPublisher.publishEvent(new CreateMatchEvent(savedMatch, lostItem, foundItem));
+
+                String title = titleCache.computeIfAbsent(lostItem.getId(),
+                        id -> itemPostRepository.findByItem(lostItem).getTitle());
+                entries.add(new CreateMatchEvent.Entry(
+                        savedMatch.getId(),
+                        savedMatch.getScore(),
+                        lostItem.getId(),
+                        lostItem.getReporter().getId(),
+                        title,
+                        foundItem.getLocationName()));
             }
+        }
+
+        if (!entries.isEmpty()) {
+            eventPublisher.publishEvent(new CreateMatchEvent(entries));
         }
         log.info("매칭 종료 ID: {}", targetItem.getId());
     }


### PR DESCRIPTION
# [리팩토링] 매칭 알림 이벤트 배치 처리로 개선

## 변경 이유
매칭 루프에서 이벤트를 건별로 발행하면 매칭 수만큼 트랜잭션과 쿼리가 발생하고, 엔티티를 직접 이벤트에 담아 `LazyInitializationException` 위험이 있었음

## 변경 내용
- 이벤트 객체를 엔티티 참조 → 원시 타입 `Entry` 리스트로 교체
- 루프 내 이벤트 발행 → 루프 후 **1회 배치 발행**
- 리스너에서 User 조회 N+1 제거 (`findAllById` 배치 조회)
- 매칭 상태 업데이트 더티 체킹 → `updateStatusInBatch` 벌크 쿼리

## 효과
매칭 N건 처리 시 이벤트 발행, User 조회, 상태 업데이트 모두 **N회 → 1회**


---
## 매칭 및 도난건 정상 작동 확인
<img width="688" height="434" alt="스크린샷 2026-05-18 18 20 43" src="https://github.com/user-attachments/assets/176ce8c1-6d88-482a-874d-4860c6a1ffd4" />
