### PR TITLE
test: 서비스 계층 단위 테스트 환경 안정화 및 거짓 양성 검증 개선

### DIFF
--- a/src/test/java/com/zoopick/server/service/AuthServiceTest.java
+++ b/src/test/java/com/zoopick/server/service/AuthServiceTest.java
@@ -1,0 +1,413 @@
+package com.zoopick.server.service;
+
+import com.zoopick.server.dto.auth.*;
+import com.zoopick.server.entity.EmailAuth;
+import com.zoopick.server.entity.User;
+import com.zoopick.server.exception.AccessTokenException;
+import com.zoopick.server.exception.BadRequestException;
+import com.zoopick.server.exception.DataNotFoundException;
+import com.zoopick.server.repository.EmailAuthRedisRepository;
+import com.zoopick.server.repository.UserRepository;
+import com.zoopick.server.security.JwtUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private EmailAuthRedisRepository emailAuthRedisRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private EmailService emailService;
+    @Mock private JwtUtil jwtUtil;
+    @Mock private TokenValidationService tokenValidationService;
+
+    @InjectMocks
+    private AuthService authService;
+
+
+    // 1. 닉네임 중복 검사 테스트 (checkNickname)
+
+
+    @Test
+    @DisplayName("사용 가능한 닉네임일 경우 성공 결과를 반환한다.")
+    void checkNickname_Success() {
+        // Given
+        String nickname = "새로운닉네임";
+        given(userRepository.findByNickname(nickname)).willReturn(Optional.empty());
+
+        // When
+        NicknameCheckResult result = authService.checkNickname(nickname);
+
+        // Then
+        assertThat(result.isAvailable()).isTrue();
+        assertThat(result.getMessage()).isEqualTo("사용 가능한 닉네임입니다.");
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 닉네임일 경우 예외가 발생한다.")
+    void checkNickname_Fail_Duplicated() {
+        // Given
+        String nickname = "중복닉네임";
+        User existingUser = User.builder().nickname(nickname).build();
+        given(userRepository.findByNickname(nickname)).willReturn(Optional.of(existingUser));
+
+        // When & Then
+        assertThatThrownBy(() -> authService.checkNickname(nickname))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(nickname+" is already in use.");
+    }
+
+
+    // 2. 회원가입 테스트 (signup)
+
+
+    @Test
+    @DisplayName("이메일 인증이 완료되지 않은 상태로 가입 시 예외가 발생한다.")
+    void signup_Fail_NotVerifiedEmail() {
+        // Given
+        SignupRequest request = createSignupRequest();
+        EmailAuth unverifiedAuth = new EmailAuth(request.getSchoolEmail(), "123456", LocalDateTime.now().plusMinutes(5), false);
+
+        given(emailAuthRedisRepository.getOrThrow(request.getSchoolEmail())).willReturn(unverifiedAuth);
+
+        // When & Then
+        assertThatThrownBy(() -> authService.signup(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(request.getSchoolEmail() + " is not verified.");
+    }
+
+    @Test
+    @DisplayName("가입 제한 시간(만료 시간)이 지난 상태로 가입 시 예외가 발생한다.")
+    void signup_Fail_SignupExpired() {
+        // Given
+        SignupRequest request = createSignupRequest();
+        LocalDateTime expiredTime = LocalDateTime.now().minusMinutes(35);
+        EmailAuth expiredAuth = new EmailAuth(request.getSchoolEmail(), "123456", expiredTime, true);
+
+        given(emailAuthRedisRepository.getOrThrow(request.getSchoolEmail())).willReturn(expiredAuth);
+
+        // When & Then
+        assertThatThrownBy(() -> authService.signup(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(request.getSchoolEmail() + " is signup expired.");
+    }
+
+    @Test
+    @DisplayName("이메일 인증은 완료되었으나, 닉네임이 이미 사용 중인 경우 예외가 발생한다.")
+    void signup_Fail_DuplicatedNickname() {
+        // Given
+        SignupRequest request = createSignupRequest();
+        EmailAuth validAuth = new EmailAuth(request.getSchoolEmail(), "123456", LocalDateTime.now().plusMinutes(5), true);
+
+        given(emailAuthRedisRepository.getOrThrow(request.getSchoolEmail())).willReturn(validAuth);
+        given(userRepository.findByNickname(request.getNickname())).willReturn(Optional.of(User.builder().build()));
+
+        // When & Then
+        assertThatThrownBy(() -> authService.signup(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("is already in use.");
+    }
+
+    @Test
+    @DisplayName("정상적인 정보로 회원가입에 성공한다.")
+    void signup_Success() {
+        // Given
+        SignupRequest request = createSignupRequest();
+        EmailAuth validAuth = new EmailAuth(request.getSchoolEmail(), "123456", LocalDateTime.now().plusMinutes(5), true);
+        User savedUser = User.builder().id(1L).schoolEmail(request.getSchoolEmail()).nickname(request.getNickname()).build();
+
+        given(emailAuthRedisRepository.getOrThrow(request.getSchoolEmail())).willReturn(validAuth);
+        given(userRepository.findByNickname(request.getNickname())).willReturn(Optional.empty());
+        given(passwordEncoder.encode(request.getPassword())).willReturn("encodedPassword");
+        given(userRepository.save(any(User.class))).willReturn(savedUser);
+        given(jwtUtil.generateToken(request.getSchoolEmail())).willReturn("mock.jwt.token");
+
+        // When
+        SignupResult result = authService.signup(request);
+
+        // Then
+        assertThat(result.getUserId()).isEqualTo(1L);
+        assertThat(result.getMessage()).isEqualTo("회원가입이 완료되었습니다.");
+        assertThat(result.getAccessToken()).isEqualTo("mock.jwt.token");
+        verify(emailAuthRedisRepository).delete(request.getSchoolEmail());
+    }
+
+    // 테스트용 픽스처(Fixture) 생성 메서드
+    private SignupRequest createSignupRequest() {
+        SignupRequest request = new SignupRequest();
+        request.setSchoolEmail("test@mju.ac.kr");
+        request.setPassword("password123!");
+        request.setNickname("캡스톤테스트");
+        request.setDepartment("컴퓨터공학과");
+        request.setGrade("4");
+        return request;
+    }
+
+
+    // 3. 로그인 테스트 (login)
+
+
+    @Test
+    @DisplayName("가입되지 않은 이메일로 로그인 시 예외가 발생한다.")
+    void login_Fail_UserNotFound() {
+        // Given
+        LoginRequest request = new LoginRequest();
+        ReflectionTestUtils.setField(request, "schoolEmail", "notfound@mju.ac.kr");
+        ReflectionTestUtils.setField(request, "password", "password123!");
+
+        given(userRepository.findBySchoolEmail(request.getSchoolEmail())).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(DataNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("비밀번호가 일치하지 않으면 로그인에 실패하고 예외가 발생한다.")
+    void login_Fail_WrongPassword() {
+        // Given
+        LoginRequest request = new LoginRequest();
+        ReflectionTestUtils.setField(request, "schoolEmail", "test@mju.ac.kr");
+        ReflectionTestUtils.setField(request, "password", "wrongPassword!");
+
+        User existingUser = User.builder()
+                .schoolEmail("test@mju.ac.kr")
+                .password("encodedPassword")
+                .build();
+
+        given(userRepository.findBySchoolEmail(request.getSchoolEmail())).willReturn(Optional.of(existingUser));
+        given(passwordEncoder.matches(request.getPassword(), existingUser.getPassword())).willReturn(false);
+
+        // When & Then
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(request.getSchoolEmail() + " failed password.");
+    }
+
+    @Test
+    @DisplayName("정상적인 이메일과 비밀번호로 로그인에 성공한다.")
+    void login_Success() {
+        // Given
+        LoginRequest request = new LoginRequest();
+        ReflectionTestUtils.setField(request, "schoolEmail", "test@mju.ac.kr");
+        ReflectionTestUtils.setField(request, "password", "password123!");
+
+        User existingUser = User.builder()
+                .schoolEmail("test@mju.ac.kr")
+                .password("encodedPassword")
+                .nickname("주픽이")
+                .department("컴퓨터공학")
+                .grade("3")
+                .build();
+
+        given(userRepository.findBySchoolEmail(request.getSchoolEmail())).willReturn(Optional.of(existingUser));
+        given(passwordEncoder.matches(request.getPassword(), existingUser.getPassword())).willReturn(true);
+        given(jwtUtil.generateToken(existingUser.getSchoolEmail())).willReturn("mock.access.token");
+
+        // When
+        LoginResult result = authService.login(request);
+
+        // Then
+        assertThat(result.getAccessToken()).isEqualTo("mock.access.token");
+        assertThat(result.getNickname()).isEqualTo("주픽이");
+        assertThat(result.getGrade()).isEqualTo("3");
+        assertThat(result.getMessage()).isEqualTo("로그인 성공");
+    }
+
+
+    // 4. 이메일 인증 발송 테스트 (sendCertificationEmail)
+
+
+    @Test
+    @DisplayName("이미 가입된 이메일로 인증을 요청하면 예외가 발생한다.")
+    void sendCertificationEmail_Fail_AlreadyJoined() {
+        // Given
+        EmailCertificationRequest request = new EmailCertificationRequest();
+        request.setEmail("test@mju.ac.kr");
+
+        given(userRepository.findBySchoolEmail(request.getEmail())).willReturn(Optional.of(User.builder().build()));
+
+        // When & Then
+        assertThatThrownBy(() -> authService.sendCertificationEmail(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(request.getEmail() + " is already in use.");
+    }
+
+    @Test
+    @DisplayName("정상적인 이메일이면 인증 메일이 발송되고 Redis에 저장된다.")
+    void sendCertificationEmail_Success() throws Exception {
+        // Given
+        EmailCertificationRequest request = new EmailCertificationRequest();
+        request.setEmail("test@mju.ac.kr");
+
+        given(userRepository.findBySchoolEmail(request.getEmail())).willReturn(Optional.empty());
+
+        // When
+        authService.sendCertificationEmail(request);
+
+        // Then
+        verify(emailAuthRedisRepository).save(any(EmailAuth.class));
+        verify(emailService).senderCertificationMail(anyString(), anyString());
+    }
+
+
+    // 5. 이메일 인증 코드 검증 테스트 (verifyCertificationCode)
+
+
+    @Test
+    @DisplayName("제출한 인증번호가 일치하지 않으면 예외가 발생한다.")
+    void verifyCertificationCode_Fail_Mismatch() {
+        // Given
+        CheckCertificationRequest request = new CheckCertificationRequest();
+        request.setEmail("test@mju.ac.kr");
+        request.setCertificationNumber("000000");
+
+        EmailAuth emailAuth = new EmailAuth(request.getEmail(), "123456", LocalDateTime.now().plusMinutes(3), false);
+        given(emailAuthRedisRepository.getOrThrow(request.getEmail())).willReturn(emailAuth);
+
+        // When & Then
+        assertThatThrownBy(() -> authService.verifyCertificationCode(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("does not match");
+    }
+
+    @Test
+    @DisplayName("제출한 인증번호는 일치하지만, 인증 시간이 만료된 경우 예외가 발생하고 Redis에서 삭제된다.")
+    void verifyCertificationCode_Fail_Expired() {
+        // Given
+        CheckCertificationRequest request = new CheckCertificationRequest();
+        request.setEmail("test@mju.ac.kr");
+        request.setCertificationNumber("123456");
+
+        // 만료된 인증 객체 생성 (현재 시간보다 1분 과거)
+        EmailAuth expiredAuth = new EmailAuth(request.getEmail(), "123456", LocalDateTime.now().minusMinutes(1), false);
+        given(emailAuthRedisRepository.getOrThrow(request.getEmail())).willReturn(expiredAuth);
+
+        // When & Then
+        assertThatThrownBy(() -> authService.verifyCertificationCode(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("expired for certification");
+
+        verify(emailAuthRedisRepository).delete(request.getEmail());
+    }
+
+    @Test
+    @DisplayName("제출한 인증번호가 일치하고 만료되지 않았다면 이메일 인증이 완료된다.")
+    void verifyCertificationCode_Success() {
+        // Given
+        CheckCertificationRequest request = new CheckCertificationRequest();
+        request.setEmail("test@mju.ac.kr");
+        request.setCertificationNumber("123456");
+
+        EmailAuth emailAuth = new EmailAuth(request.getEmail(), "123456", LocalDateTime.now().plusMinutes(3), false);
+        given(emailAuthRedisRepository.getOrThrow(request.getEmail())).willReturn(emailAuth);
+
+        // When
+        authService.verifyCertificationCode(request);
+
+        // Then
+        assertThat(emailAuth.isVerified()).isTrue();
+        verify(emailAuthRedisRepository).save(emailAuth);
+    }
+
+
+    // 6. Access Token 검증 및 재발급 테스트 (validateAccessToken)
+
+
+    @Test
+    @DisplayName("유효하지 않은 토큰일 경우 AccessTokenException이 발생한다.")
+    void validateAccessToken_Fail_InvalidToken() {
+        // Given
+        String invalidToken = "invalid.token";
+        given(tokenValidationService.validateTokenOrThrow(invalidToken)).willReturn(false);
+
+        // When & Then
+        assertThatThrownBy(() -> authService.validateAccessToken(invalidToken))
+                .isInstanceOf(AccessTokenException.class)
+                .hasMessageContaining("expired or invalidated");
+    }
+
+    @Test
+    @DisplayName("토큰은 유효하지만 DB에 해당하는 유저가 없을 경우 예외가 발생한다.")
+    void validateAccessToken_Fail_UserNotFound() {
+        // Given
+        String oldToken = "old.jwt.token";
+        String email = "notfound@mju.ac.kr";
+
+        given(tokenValidationService.validateTokenOrThrow(oldToken)).willReturn(true);
+        given(jwtUtil.extractEmail(oldToken)).willReturn(email);
+        given(userRepository.findBySchoolEmail(email)).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> authService.validateAccessToken(oldToken))
+                .isInstanceOf(DataNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("유효한 토큰일 경우 기존 토큰을 무효화하고 새로운 토큰을 발급한다.")
+    void validateAccessToken_Success() {
+        // Given
+        String oldToken = "old.jwt.token";
+        String email = "test@mju.ac.kr";
+
+        given(tokenValidationService.validateTokenOrThrow(oldToken)).willReturn(true);
+        given(jwtUtil.extractEmail(oldToken)).willReturn(email);
+        given(userRepository.findBySchoolEmail(email)).willReturn(Optional.of(User.builder().build()));
+        given(jwtUtil.generateToken(email)).willReturn("new.jwt.token");
+
+        // When
+        String resultToken = authService.validateAccessToken(oldToken);
+
+        // Then
+        assertThat(resultToken).isEqualTo("new.jwt.token");
+        verify(tokenValidationService).invalidateToken(oldToken);
+    }
+
+
+    // 7. 로그아웃 테스트 (logout)
+
+
+    @Test
+    @DisplayName("유효하지 않은 토큰으로 로그아웃 시 예외가 발생한다.")
+    void logout_Fail_InvalidToken() {
+        // Given
+        String invalidToken = "invalid.token";
+        given(tokenValidationService.validateTokenOrThrow(invalidToken)).willReturn(false);
+
+        // When & Then
+        assertThatThrownBy(() -> authService.logout(invalidToken))
+                .isInstanceOf(AccessTokenException.class)
+                .hasMessageContaining("expired or invalidated");
+    }
+
+    @Test
+    @DisplayName("로그아웃 시 현재 유효한 토큰을 무효화(블랙리스트 처리)한다.")
+    void logout_Success() {
+        // Given
+        String token = "valid.jwt.token";
+        given(tokenValidationService.validateTokenOrThrow(token)).willReturn(true);
+
+        // When
+        authService.logout(token);
+
+        // Then
+        verify(tokenValidationService).invalidateToken(token);
+    }
+}

--- a/src/test/java/com/zoopick/server/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/zoopick/server/service/ChatRoomServiceTest.java
@@ -1,0 +1,214 @@
+package com.zoopick.server.service;
+
+import com.zoopick.server.dto.chat.ChatRoomCloseReason;
+import com.zoopick.server.dto.chat.ChatRoomRecord;
+import com.zoopick.server.dto.chat.CreateChatRoomRequest;
+import com.zoopick.server.dto.chat.CreateChatRoomResult;
+import com.zoopick.server.entity.*;
+import com.zoopick.server.exception.BadRequestException;
+import com.zoopick.server.mapper.ChatMessageMapper;
+import com.zoopick.server.mapper.ChatRoomMapper;
+import com.zoopick.server.repository.ChatMessageRepository;
+import com.zoopick.server.repository.ChatRoomRepository;
+import com.zoopick.server.repository.ItemRepository;
+import com.zoopick.server.repository.UserRepository;
+import com.zoopick.server.service.notification.NotificationService;
+import com.zoopick.server.service.notification.SendNotificationCommand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomServiceTest {
+
+    @InjectMocks
+    private ChatRoomService chatRoomService;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+    @Mock
+    private ItemRepository itemRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+    @Mock
+    private NotificationService notificationService;
+    @Mock
+    private ChatMessageMapper chatMessageMapper;
+    @Mock
+    private ChatRoomMapper chatRoomMapper;
+
+    private User requester;
+    private User counterpart;
+    private Item foundItem;
+    private ChatRoom openChatRoom;
+
+    @BeforeEach
+    void setUp() {
+        requester = User.builder().id(1L).nickname("requester").build();
+        counterpart = User.builder().id(2L).nickname("counterpart").build();
+
+        foundItem = Item.builder().id(10L).type(ItemType.FOUND).build();
+
+        openChatRoom = ChatRoom.builder()
+                .id(100L)
+                .item(foundItem)
+                .owner(requester)     // 1L
+                .finder(counterpart)  // 2L
+                .status(ChatRoomStatus.OPEN)
+                .build();
+    }
+
+    @Test
+    @DisplayName("채팅방 생성 - 본인에게 요청 시 BadRequestException 발생")
+    void createChatRoom_fail_whenRequesterAndCounterpartAreSame() {
+        // given
+        CreateChatRoomRequest request = new CreateChatRoomRequest(10L, 1L);
+
+        // when & then
+        BadRequestException exception = assertThrows(BadRequestException.class,
+                () -> chatRoomService.createChatRoom(1L, request));
+
+        assertEquals("잘못된 요청입니다.", exception.getClientMessage());
+        verify(chatRoomRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("채팅방 생성 - 이미 존재하는 채팅방인 경우 기존 채팅방 반환")
+    void createChatRoom_returnsExistingChatRoom() {
+        // given
+        CreateChatRoomRequest request = new CreateChatRoomRequest(10L, 2L);
+        ChatRoomRecord mockRecord = mock(ChatRoomRecord.class);
+
+        when(itemRepository.findByIdOrThrow(10L)).thenReturn(foundItem);
+        when(userRepository.findByIdOrThrow(1L)).thenReturn(requester);
+        when(userRepository.findByIdOrThrow(2L)).thenReturn(counterpart);
+
+        when(chatRoomRepository.findOpenByParticipantAndItem(1L, 10L))
+                .thenReturn(Optional.of(openChatRoom));
+        when(chatRoomMapper.toChatRoomRecord(openChatRoom)).thenReturn(mockRecord);
+
+        // when
+        CreateChatRoomResult result = chatRoomService.createChatRoom(1L, request);
+
+        // then
+        assertFalse(result.isCreated()); // 생성되지 않음
+        assertNotNull(result.getRoomData());
+        verify(chatRoomRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("채팅방 생성 - FOUND 아이템에 대해 정상적으로 채팅방 생성")
+    void createChatRoom_success_forFoundItem() {
+        // given
+        CreateChatRoomRequest request = new CreateChatRoomRequest(10L, 2L);
+        ChatRoomRecord mockRecord = mock(ChatRoomRecord.class);
+
+        when(itemRepository.findByIdOrThrow(10L)).thenReturn(foundItem);
+        when(userRepository.findByIdOrThrow(1L)).thenReturn(requester);
+        when(userRepository.findByIdOrThrow(2L)).thenReturn(counterpart);
+
+        when(chatRoomRepository.findOpenByParticipantAndItem(1L, 10L)).thenReturn(Optional.empty());
+
+        when(chatRoomRepository.save(any(ChatRoom.class))).thenReturn(openChatRoom);
+        when(chatRoomMapper.toChatRoomRecord(openChatRoom)).thenReturn(mockRecord);
+
+        // when
+        CreateChatRoomResult result = chatRoomService.createChatRoom(1L, request);
+
+        // then
+        assertTrue(result.isCreated());
+        verify(chatRoomRepository, times(1)).save(any(ChatRoom.class));
+    }
+
+    @Test
+    @DisplayName("메시지 전송 - 참여자가 아닌 경우 예외 발생")
+    void sendMessageWithNotification_fail_whenNotParticipant() {
+        // given
+        User stranger = User.builder().id(3L).build();
+        when(userRepository.findByIdOrThrow(3L)).thenReturn(stranger);
+        when(chatRoomRepository.findByIdOrThrow(100L)).thenReturn(openChatRoom);
+
+        // when & then
+        assertThrows(BadRequestException.class,
+                () -> chatRoomService.sendMessageWithNotification(3L, 100L, "Hello!"));
+    }
+
+    @Test
+    @DisplayName("메시지 전송 - 닫힌 방에 전송 시 예외 발생")
+    void sendMessageWithNotification_fail_whenChatRoomIsClosed() {
+        // given
+        openChatRoom.setStatus(ChatRoomStatus.RESOLVED_RETURNED);
+        when(userRepository.findByIdOrThrow(1L)).thenReturn(requester);
+        when(chatRoomRepository.findByIdOrThrow(100L)).thenReturn(openChatRoom);
+
+        // when & then
+        assertThrows(BadRequestException.class,
+                () -> chatRoomService.sendMessageWithNotification(1L, 100L, "Hello!"));
+    }
+
+    @Test
+    @DisplayName("메시지 전송 - 성공 시 메시지 저장 및 알림 전송 (sendMessageWithNotification)")
+    void sendMessageWithNotification_success() {
+        // given
+        String message = "안녕하세요!";
+        when(userRepository.findByIdOrThrow(1L)).thenReturn(requester);
+        when(chatRoomRepository.findByIdOrThrow(100L)).thenReturn(openChatRoom);
+
+        // when: 알림 발송이 포함된 public 메서드를 호출합니다.
+        chatRoomService.sendMessageWithNotification(1L, 100L, message);
+
+        // then
+        verify(chatMessageRepository, times(1)).save(any(ChatMessage.class));
+        verify(notificationService, times(1)).send(eq(counterpart), any(SendNotificationCommand.class));
+    }
+
+    @Test
+    @DisplayName("채팅방 닫기 - 성공적으로 닫히고 알림 전송")
+    void closeChatRoom_success() {
+        // given
+        when(userRepository.findByIdOrThrow(1L)).thenReturn(requester);
+        when(chatRoomRepository.findByIdOrThrow(100L)).thenReturn(openChatRoom);
+
+        // when
+        chatRoomService.closeChatRoom(1L, 100L, ChatRoomCloseReason.RETURNED);
+
+        // then
+        assertEquals(ChatRoomStatus.RESOLVED_RETURNED, openChatRoom.getStatus());
+        assertNotNull(openChatRoom.getResolvedAt());
+        verify(chatRoomRepository, times(1)).save(openChatRoom);
+        verify(notificationService, times(1)).send(eq(counterpart), any(SendNotificationCommand.class));
+    }
+
+    @Test
+    @DisplayName("채팅방 다시 열기 - 성공적으로 열리고 알림 전송")
+    void reopenChatRoom_success() {
+        // given
+        openChatRoom.setStatus(ChatRoomStatus.RESOLVED_RETURNED);
+        openChatRoom.setResolvedAt(java.time.LocalDateTime.now());
+
+        when(userRepository.findByIdOrThrow(1L)).thenReturn(requester);
+        when(chatRoomRepository.findByIdOrThrow(100L)).thenReturn(openChatRoom);
+
+        // when
+        chatRoomService.reopenChatRoom(1L, 100L);
+
+        // then
+        assertEquals(ChatRoomStatus.OPEN, openChatRoom.getStatus());
+        assertNull(openChatRoom.getResolvedAt());
+        verify(chatRoomRepository, times(1)).save(openChatRoom);
+        verify(notificationService, times(1)).send(eq(counterpart), any(SendNotificationCommand.class));
+    }
+}

--- a/src/test/java/com/zoopick/server/service/EmailServiceTest.java
+++ b/src/test/java/com/zoopick/server/service/EmailServiceTest.java
@@ -1,0 +1,62 @@
+package com.zoopick.server.service;
+
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.Resource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTest {
+
+    @InjectMocks
+    private EmailService emailService;
+
+    @Mock
+    private JavaMailSender javaMailSender;
+
+    @Mock
+    private Resource resource;
+
+    @BeforeEach
+    void setUp() {
+        // @Value 로 주입되는 resource 필드를 리플렉션으로 설정
+        ReflectionTestUtils.setField(emailService, "resource", resource);
+    }
+
+    @Test
+    @DisplayName("인증 메일 전송 - 성공적으로 MimeMessage를 생성하고 전송한다")
+    void senderCertificationMail_Success() throws Exception {
+        // given
+        String email = "test@mju.ac.kr";
+        String certificationNumber = "123456";
+        String templateContent = "<html>인증번호: ${certificationNumber}</html>";
+        InputStream inputStream = new ByteArrayInputStream(templateContent.getBytes(StandardCharsets.UTF_8));
+
+        MimeMessage mimeMessage = mock(MimeMessage.class);
+
+        given(resource.getInputStream()).willReturn(inputStream);
+        given(javaMailSender.createMimeMessage()).willReturn(mimeMessage);
+
+        // when
+        emailService.senderCertificationMail(email, certificationNumber);
+
+        // then
+        verify(javaMailSender).createMimeMessage();
+        verify(javaMailSender).send(mimeMessage);
+    }
+}

--- a/src/test/java/com/zoopick/server/service/ImageServiceTest.java
+++ b/src/test/java/com/zoopick/server/service/ImageServiceTest.java
@@ -1,0 +1,142 @@
+package com.zoopick.server.service;
+
+import com.zoopick.server.dto.image.ImageUploadResult;
+import com.zoopick.server.exception.BadRequestException;
+import com.zoopick.server.exception.DataNotFoundException;
+import com.zoopick.server.image.ImagePurpose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.Resource;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+class ImageServiceTest {
+
+    private ImageService imageService;
+
+    // JUnit5가 제공하는 임시 디렉토리 (테스트 종료 시 자동 삭제됨)
+    @TempDir
+    Path tempUploadDir;
+
+    private ImagePurpose testPurpose;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        // @Value 주입 대신 임시 디렉토리 경로를 생성자로 넘겨 객체 생성
+        imageService = new ImageService(tempUploadDir.toString());
+
+        // ImagePurpose Enum 중 첫 번째 값을 테스트용으로 사용
+        testPurpose = ImagePurpose.values()[0];
+
+        // 디렉토리 초기화 로직 실행
+        imageService.init();
+    }
+
+    @Test
+    @DisplayName("정상적인 이미지 파일 업로드 성공")
+    void upload_Success() {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+                "image",
+                "test-image.png",
+                "image/png",
+                "dummy image content".getBytes()
+        );
+
+        // when
+        ImageUploadResult result = imageService.upload(testPurpose, file);
+
+        // then
+        assertThat(result).isNotNull();
+        // 수정됨: result.originalFilename() -> result.getOriginalFilename()
+        assertThat(result.getOriginalFilename()).isEqualTo("test-image.png");
+        // 수정됨: result.imageUrl() -> result.getImageUrl()
+        assertThat(result.getImageUrl()).contains(testPurpose.getUrl());
+    }
+
+    @Test
+    @DisplayName("파일이 비어있으면 예외 발생")
+    void upload_Fail_EmptyFile() {
+        // given
+        MockMultipartFile emptyFile = new MockMultipartFile("image", "empty.png", "image/png", new byte[0]);
+
+        // when & then
+        assertThatThrownBy(() -> imageService.upload(testPurpose, emptyFile))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("비어 있습니다");
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 Content-Type 업로드 시 예외 발생")
+    void upload_Fail_InvalidContentType() {
+        // given
+        MockMultipartFile textFile = new MockMultipartFile(
+                "image",
+                "test.txt",
+                "text/plain",
+                "text content".getBytes()
+        );
+
+        // when & then
+        assertThatThrownBy(() -> imageService.upload(testPurpose, textFile))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("형식의 이미지만 업로드");
+    }
+
+    @Test
+    @DisplayName("확장자가 없는 파일 업로드 시 예외 발생")
+    void upload_Fail_NoExtension() {
+        // given
+        MockMultipartFile noExtFile = new MockMultipartFile(
+                "image",
+                "filenameWithoutDot",
+                "image/png",
+                "content".getBytes()
+        );
+
+        // when & then
+        assertThatThrownBy(() -> imageService.upload(testPurpose, noExtFile))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("확장자가 없는 파일");
+    }
+
+    @Test
+    @DisplayName("존재하는 이미지 리소스 불러오기 성공")
+    void loadAsResource_Success() throws IOException {
+        // given: 먼저 파일을 업로드하여 저장
+        MockMultipartFile file = new MockMultipartFile("image", "load-test.jpg", "image/jpeg", "content".getBytes());
+        ImageUploadResult uploadResult = imageService.upload(testPurpose, file);
+
+        String imageUrl = uploadResult.getImageUrl();
+        String storedFileName = imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
+
+        // when
+        Resource resource = imageService.loadAsResource(testPurpose, storedFileName);
+
+        // then
+        assertThat(resource).isNotNull();
+        assertThat(resource.exists()).isTrue();
+        assertThat(resource.isReadable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이미지 불러오기 시 DataNotFoundException 발생")
+    void loadAsResource_Fail_NotFound() {
+        // given
+        String notFoundFileName = "not-exist-file.png";
+
+        // when & then
+        assertThatThrownBy(() -> imageService.loadAsResource(testPurpose, notFoundFileName))
+                .isInstanceOf(DataNotFoundException.class);
+    }
+}

--- a/src/test/java/com/zoopick/server/service/ItemMatchServiceTest.java
+++ b/src/test/java/com/zoopick/server/service/ItemMatchServiceTest.java
@@ -1,0 +1,276 @@
+package com.zoopick.server.service;
+
+import com.zoopick.server.config.MatchConfig;
+import com.zoopick.server.dto.match.*;
+import com.zoopick.server.entity.*;
+import com.zoopick.server.exception.BadRequestException;
+import com.zoopick.server.repository.ItemMatchRepository;
+import com.zoopick.server.repository.ItemPostRepository;
+import com.zoopick.server.repository.ItemRepository;
+import com.zoopick.server.repository.LockerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Vector;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ItemMatchServiceTest {
+
+    @InjectMocks
+    private ItemMatchService itemMatchService;
+
+    @Mock private ItemRepository itemRepository;
+    @Mock private ItemMatchRepository itemMatchRepository;
+    @Mock private ItemPostRepository itemPostRepository;
+    @Mock private LockerRepository lockerRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private MatchConfig matchConfig; // 추가된 의존성
+
+    private User requester;
+    private User counterpart;
+    private Item lostItem;
+    private Item foundItem;
+    private ItemMatch itemMatch;
+
+    @BeforeEach
+    void setUp() {
+        requester = User.builder().id(1L).nickname("신고자").build();
+        counterpart = User.builder().id(2L).nickname("발견자").build();
+
+        lostItem = Item.builder()
+                .id(100L)
+                .reporter(requester) // userId: 1L
+                .type(ItemType.LOST)
+                .category(ItemCategory.BAG)
+                .color(ItemColor.BLACK)
+                .embedding(new float[]{0.1f, 0.2f})
+                .status(ItemStatus.REPORTED)
+                .build();
+
+        foundItem = Item.builder()
+                .id(200L)
+                .reporter(counterpart) // userId: 2L
+                .type(ItemType.FOUND)
+                .category(ItemCategory.BAG)
+                .color(ItemColor.BLACK)
+                .embedding(new float[]{0.1f, 0.2f})
+                .status(ItemStatus.REPORTED)
+                .build();
+
+        itemMatch = ItemMatch.builder()
+                .id(10L)
+                .lostItem(lostItem)
+                .foundItem(foundItem)
+                .status(MatchStatus.CANDIDATE)
+                .score(0.95f)
+                .build();
+    }
+
+    @Test
+    @DisplayName("자동 매칭 생성 - 성공 (이벤트 발행 포함)")
+    void createMatch_success() {
+        // given
+        // MatchConfig 설정 모킹
+        when(matchConfig.getSimilarityThreshold()).thenReturn(0.8f);
+        when(matchConfig.getColorBonus()).thenReturn(1.02f);
+
+        // 유사 아이템 Projection 모킹
+        SimilarItemProjection projectionMock = mock(SimilarItemProjection.class);
+        when(projectionMock.getItemId()).thenReturn(200L);
+        when(projectionMock.getScore()).thenReturn(0.95); // Double 반환
+
+        when(itemRepository.findByIdOrThrow(100L)).thenReturn(lostItem);
+
+        when(itemMatchRepository.findSimilarItems(
+                any(Vector.class),
+                eq("LOST"),
+                eq("BAG"),
+                eq(1L),
+                eq(0.8f)
+        )).thenReturn(List.of(projectionMock));
+
+        when(itemRepository.findAllById(anyList())).thenReturn(List.of(foundItem));
+        when(itemMatchRepository.existsByLostItemAndFoundItem(lostItem, foundItem)).thenReturn(false);
+        when(itemMatchRepository.save(any(ItemMatch.class))).thenReturn(itemMatch);
+
+        // 게시글(ItemPost) 타이틀 캐싱 조회 모킹
+        ItemPost itemPost = ItemPost.builder().id(1000L).title("분실물 게시글").build();
+        when(itemPostRepository.findByItem(lostItem)).thenReturn(itemPost);
+
+        // when
+        itemMatchService.createMatch(100L);
+
+        // then
+        verify(itemMatchRepository, times(1)).save(any(ItemMatch.class));
+        verify(eventPublisher, times(1)).publishEvent(any(CreateMatchEvent.class));
+    }
+
+    @Test
+    @DisplayName("자동 매칭 생성 - 유사 아이템이 없는 경우 그대로 종료")
+    void createMatch_noSimilarItems() {
+        // given
+        when(itemRepository.findByIdOrThrow(100L)).thenReturn(lostItem);
+        when(matchConfig.getSimilarityThreshold()).thenReturn(0.8f);
+
+        when(itemMatchRepository.findSimilarItems(
+                any(Vector.class),
+                anyString(),
+                anyString(),
+                anyLong(),
+                anyFloat()
+        )).thenReturn(List.of()); // 빈 리스트 반환
+
+        // when
+        itemMatchService.createMatch(100L);
+
+        // then
+        verify(itemRepository, never()).findAllById(anyList());
+        verify(itemMatchRepository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("매칭 결과 목록 조회 - 성공")
+    void getItemMatchResult_success() {
+        // given
+        Long userId = 1L;
+
+        // 실제 Repository 메서드 호출 및 DTO 객체 리스트 반환 모킹
+        ItemMatchResultResponse responseMock = new ItemMatchResultResponse(
+                10L, 200L, 1000L, "분실물 게시글 제목", "http://image.url",
+                "도서관", "착한발견자", "컴퓨터공학과", 0.95f, MatchStatus.CANDIDATE, 2L
+        );
+        when(itemMatchRepository.findMatchResultsByUserId(userId)).thenReturn(List.of(responseMock));
+
+        // when
+        List<ItemMatchResultResponse> responses = itemMatchService.getItemMatchResult(userId);
+
+        // then
+        assertFalse(responses.isEmpty());
+        assertEquals(10L, responses.get(0).getMatchId());
+        assertEquals(MatchStatus.CANDIDATE, responses.get(0).getStatus());
+        assertEquals("분실물 게시글 제목", responses.get(0).getFoundPostTitle());
+    }
+
+    @Test
+    @DisplayName("매칭 확정 - 성공 (채팅 매칭)")
+    void confirmMatch_success_chat() {
+        // given
+        Long matchId = 10L;
+        Long userId = 1L; // requester(1L)만이 소유자 권한 통과
+
+        when(itemMatchRepository.findByIdOrThrow(matchId)).thenReturn(itemMatch);
+        // 상태 검증 모킹
+        when(itemMatchRepository.existsByLostItemAndStatus(lostItem, MatchStatus.CONFIRMED)).thenReturn(false);
+        when(itemMatchRepository.existsByFoundItemAndStatus(foundItem, MatchStatus.CONFIRMED)).thenReturn(false);
+
+        // when (파라미터: matchId, userId)
+        MatchConfirmResponse response = itemMatchService.confirmMatch(matchId, userId);
+
+        // then
+        assertEquals(MatchStatus.CONFIRMED, itemMatch.getStatus());
+        assertEquals(ItemStatus.MATCHED, lostItem.getStatus());
+        assertEquals(ItemStatus.MATCHED, foundItem.getStatus());
+
+        assertEquals(MatchManualType.CHAT, response.getMatchType());
+        verify(itemMatchRepository, times(1)).rejectOthersByLostItem(10L, 100L, 200L);
+    }
+
+    @Test
+    @DisplayName("매칭 확정 실패 - 본인의 매칭이 아닐 때 권한 예외 발생")
+    void confirmMatch_fail_notOwner() {
+        // given
+        Long matchId = 10L;
+        Long wrongUserId = 999L; // 소유자가 아닌 유저
+        when(itemMatchRepository.findByIdOrThrow(matchId)).thenReturn(itemMatch);
+
+        // when & then
+        BadRequestException exception = assertThrows(BadRequestException.class,
+                () -> itemMatchService.confirmMatch(matchId, wrongUserId));
+        assertEquals("본인의 매칭만 처리할 수 있습니다.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("매칭 거절 - 성공")
+    void rejectMatch_success() {
+        // given
+        Long matchId = 10L;
+        Long userId = 1L;
+
+        when(itemMatchRepository.findByIdOrThrow(matchId)).thenReturn(itemMatch);
+        when(itemMatchRepository.existsByLostItemAndStatus(lostItem, MatchStatus.CONFIRMED)).thenReturn(false);
+        when(itemMatchRepository.existsByFoundItemAndStatus(foundItem, MatchStatus.CONFIRMED)).thenReturn(false);
+
+        // when
+        itemMatchService.rejectMatch(matchId, userId);
+
+        // then
+        assertEquals(MatchStatus.REJECTED, itemMatch.getStatus());
+    }
+
+    @Test
+    @DisplayName("수동 매칭 - 보관함(Locker) 아이템 성공")
+    void matchManual_locker_success() {
+        // given
+        MatchManualRequest request = mock(MatchManualRequest.class);
+        when(request.getLostItemId()).thenReturn(100L);
+        when(request.getFoundItemId()).thenReturn(200L);
+
+        foundItem.setStatus(ItemStatus.IN_LOCKER); // 보관함 상태로 변경
+        Locker locker = Locker.builder().id(5L).build();
+
+        when(itemRepository.findByIdOrThrow(100L)).thenReturn(lostItem);
+        when(itemRepository.findByIdOrThrow(200L)).thenReturn(foundItem);
+
+        when(itemMatchRepository.existsByLostItemAndFoundItem(lostItem, foundItem)).thenReturn(false);
+        when(itemMatchRepository.existsByLostItemAndStatus(lostItem, MatchStatus.CONFIRMED)).thenReturn(false);
+        when(itemMatchRepository.existsByFoundItemAndStatus(foundItem, MatchStatus.CONFIRMED)).thenReturn(false);
+
+        when(itemMatchRepository.save(any(ItemMatch.class))).thenReturn(itemMatch);
+        when(lockerRepository.findLockerByCurrentItem(foundItem)).thenReturn(locker);
+
+        // when
+        MatchManualResponse response = itemMatchService.matchManual(request);
+
+        // then
+        assertEquals(MatchManualType.LOCKER, response.getMatchManualType());
+        assertEquals(5L, response.getLockerId());
+        verify(itemMatchRepository, times(1)).rejectOthersByLostItem(itemMatch.getId(), 100L, 200L);
+    }
+
+    @Test
+    @DisplayName("수동 매칭 - 채팅(Chat) 아이템 성공")
+    void matchManual_chat_success() {
+        // given
+        MatchManualRequest request = mock(MatchManualRequest.class);
+        when(request.getLostItemId()).thenReturn(100L);
+        when(request.getFoundItemId()).thenReturn(200L);
+
+        when(itemRepository.findByIdOrThrow(100L)).thenReturn(lostItem);
+        when(itemRepository.findByIdOrThrow(200L)).thenReturn(foundItem);
+
+        when(itemMatchRepository.existsByLostItemAndFoundItem(lostItem, foundItem)).thenReturn(false);
+        when(itemMatchRepository.existsByLostItemAndStatus(lostItem, MatchStatus.CONFIRMED)).thenReturn(false);
+        when(itemMatchRepository.existsByFoundItemAndStatus(foundItem, MatchStatus.CONFIRMED)).thenReturn(false);
+
+        when(itemMatchRepository.save(any(ItemMatch.class))).thenReturn(itemMatch);
+
+        // when
+        MatchManualResponse response = itemMatchService.matchManual(request);
+
+        // then
+        assertEquals(MatchManualType.CHAT, response.getMatchManualType());
+        assertNull(response.getLockerId());
+    }
+}

--- a/src/test/java/com/zoopick/server/service/ItemPostServiceTest.java
+++ b/src/test/java/com/zoopick/server/service/ItemPostServiceTest.java
@@ -1,0 +1,157 @@
+package com.zoopick.server.service;
+
+import com.zoopick.server.dto.item.*;
+import com.zoopick.server.entity.*;
+import com.zoopick.server.mapper.ItemPostMapper;
+import com.zoopick.server.repository.BuildingRepository;
+import com.zoopick.server.repository.ItemPostRepository;
+import com.zoopick.server.repository.ItemRepository;
+import com.zoopick.server.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ItemPostServiceTest {
+
+    @InjectMocks
+    private ItemPostService itemPostService;
+
+    @Mock
+    private ItemRepository itemRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private ItemPostRepository itemPostRepository;
+    @Mock
+    private BuildingRepository buildingRepository;
+    @Mock
+    private ItemPostMapper itemPostMapper;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private User user;
+    private Building building;
+    private Item item;
+    private ItemPost itemPost;
+
+    @BeforeEach
+    void setUp() {
+        // 공통적으로 사용될 테스트 데이터 세팅
+        user = User.builder().id(1L).nickname("테스트유저").build();
+        building = Building.builder().id(10L).name("명진당").build();
+
+        item = Item.builder()
+                .id(100L)
+                .reporter(user)
+                //.type(ItemType.FOUND) // 실제 Entity에 정의된 Enum 활용
+                .status(ItemStatus.REPORTED)
+                .reportedBuilding(building)
+                .build();
+
+        itemPost = ItemPost.builder()
+                .id(1000L)
+                .title("지갑 찾습니다")
+                .description("검은색 가죽 지갑입니다.")
+                .user(user)
+                .item(item)
+                .build();
+    }
+
+    @Test
+    @DisplayName("게시글 생성 - 정상 처리 및 이벤트 발행 검증")
+    void createItemPost_success() {
+        // given
+        CreateItemPostRequest request = mock(CreateItemPostRequest.class);
+        when(request.getBuildingId()).thenReturn(10L);
+        when(request.getTitle()).thenReturn("지갑 찾습니다");
+        when(request.getDescription()).thenReturn("검은색 가죽 지갑입니다.");
+        when(request.getReportedAt()).thenReturn(LocalDateTime.now());
+
+        when(userRepository.findByIdOrThrow(1L)).thenReturn(user);
+        when(buildingRepository.findByIdOrThrow(10L)).thenReturn(building);
+
+        when(itemRepository.save(any(Item.class))).thenReturn(item);
+        when(itemPostRepository.save(any(ItemPost.class))).thenReturn(itemPost);
+
+        // when
+        CreateItemPostResult result = itemPostService.createItemPost(1L, request);
+
+        // then
+        assertNotNull(result);
+
+        ArgumentCaptor<Item> itemCaptor = ArgumentCaptor.forClass(Item.class);
+
+        verify(itemRepository, times(1)).save(itemCaptor.capture());
+
+        Item savedItem = itemCaptor.getValue();
+        assertEquals(ItemStatus.REPORTED, savedItem.getStatus());
+
+        // 나머지 검증
+        verify(itemPostRepository, times(1)).save(any(ItemPost.class));
+        verify(eventPublisher, times(1)).publishEvent(any(ItemCreatedEvent.class));
+    }
+
+    @Test
+    @DisplayName("게시글 목록 조회 - 페이지네이션 적용 성공")
+    void getItemPosts_success() {
+        // given
+        ItemPostFilter filter = mock(ItemPostFilter.class);
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<ItemPost> itemPostPage = new PageImpl<>(List.of(itemPost), pageable, 1);
+        ItemPostRecord recordMock = mock(ItemPostRecord.class);
+
+        // Specification 파라미터 매칭을 위해 any() 사용
+        when(itemPostRepository.findAll(any(Specification.class), eq(pageable))).thenReturn(itemPostPage);
+        when(itemPostMapper.toItemPostRecord(any(ItemPost.class))).thenReturn(recordMock);
+
+        // when
+        ListItemPostResult result = itemPostService.getItemPosts(filter, pageable);
+
+        // then
+        assertNotNull(result);
+
+        verify(itemPostRepository, times(1)).findAll(any(Specification.class), eq(pageable));
+        verify(itemPostMapper, times(1)).toItemPostRecord(itemPost);
+    }
+
+    @Test
+    @DisplayName("단일 게시글 조회 - 성공")
+    void getItemPost_success() {
+        // given
+        ItemPostRecord recordMock = mock(ItemPostRecord.class);
+
+        when(itemPostRepository.findByIdOrThrow(1000L)).thenReturn(itemPost);
+        when(itemPostMapper.toItemPostRecord(itemPost)).thenReturn(recordMock);
+
+        // when
+        ItemPostRecord result = itemPostService.getItemPost(1000L);
+
+        // then
+        assertNotNull(result);
+        assertEquals(recordMock, result);
+
+        verify(itemPostRepository, times(1)).findByIdOrThrow(1000L);
+        verify(itemPostMapper, times(1)).toItemPostRecord(itemPost);
+    }
+}

--- a/src/test/java/com/zoopick/server/service/LockerServiceTest.java
+++ b/src/test/java/com/zoopick/server/service/LockerServiceTest.java
@@ -1,0 +1,306 @@
+package com.zoopick.server.service;
+
+import com.zoopick.server.entity.*;
+import com.zoopick.server.exception.BadRequestException;
+import com.zoopick.server.exception.ForbiddenException;
+import com.zoopick.server.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LockerServiceTest {
+
+    @InjectMocks
+    private LockerService lockerService;
+
+    @Mock private LockerRepository lockerRepository;
+    @Mock private LockerCommandRepository commandRepository;
+    @Mock private ItemRepository itemRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private ItemMatchRepository itemMatchRepository;
+
+    // 💡 NullPointerException 해결을 위해 추가된 의존성 Mocking
+    @Mock private ChatRoomRepository chatRoomRepository;
+
+    private User mockUser;
+    private User otherUser;
+    private Locker emptyLocker;
+    private Locker fullLocker;
+    private Item validItem;
+    private Item storedItem;
+
+    private final Long MOCK_USER_ID = 1L;
+    private final Long OTHER_USER_ID = 2L;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = User.builder().id(MOCK_USER_ID).build();
+        otherUser = User.builder().id(OTHER_USER_ID).build();
+
+        emptyLocker = Locker.builder()
+                .id(1L)
+                .status(LockerStatus.EMPTY)
+                .currentItem(null)
+                .build();
+
+        storedItem = Item.builder()
+                .id(100L)
+                .reporter(mockUser) // 신고자를 mockUser로 설정
+                .status(ItemStatus.IN_LOCKER)
+                .build();
+
+        fullLocker = Locker.builder()
+                .id(2L)
+                .status(LockerStatus.IN_USE)
+                .currentItem(storedItem)
+                .build();
+
+        validItem = Item.builder()
+                .id(200L)
+                .reporter(mockUser) // 신고자를 mockUser로 설정
+                .type(ItemType.FOUND) // 습득물
+                .status(ItemStatus.REPORTED)
+                .build();
+    }
+
+    @Test
+    @DisplayName("사물함 열기 요청 - 보관 (빈 사물함 + 본인이 신고한 습득물)")
+    void requestUnlock_Storage_Success() {
+        // given
+        when(userRepository.findById(MOCK_USER_ID)).thenReturn(Optional.of(mockUser));
+        when(lockerRepository.findById(1L)).thenReturn(Optional.of(emptyLocker));
+        when(itemRepository.findById(200L)).thenReturn(Optional.of(validItem));
+        when(commandRepository.save(any(LockerCommand.class))).thenAnswer(i -> i.getArgument(0));
+
+        // when (파라미터: userId, lockerId, itemId)
+        LockerCommand command = lockerService.requestUnlock(MOCK_USER_ID, 1L, 200L);
+
+        // then
+        assertEquals(LockerStatus.IN_USE, emptyLocker.getStatus());
+        assertEquals(validItem, emptyLocker.getCurrentItem());
+        assertEquals(ItemStatus.IN_LOCKER, validItem.getStatus());
+
+        assertEquals(LockerCommandType.OPEN, command.getCommand());
+        assertEquals(mockUser, command.getIssuedBy());
+        verify(commandRepository, times(1)).save(any(LockerCommand.class));
+    }
+
+    @Test
+    @DisplayName("사물함 열기 요청 - 보관 실패 (타인이 신고한 물품)")
+    void requestUnlock_Storage_Fail_NotReporter() {
+        // given
+        validItem.setReporter(otherUser); // 다른 사람이 신고한 물품으로 변경
+        when(userRepository.findById(MOCK_USER_ID)).thenReturn(Optional.of(mockUser));
+        when(lockerRepository.findById(1L)).thenReturn(Optional.of(emptyLocker));
+        when(itemRepository.findById(200L)).thenReturn(Optional.of(validItem));
+
+        // when & then
+        assertThrows(ForbiddenException.class,
+                () -> lockerService.requestUnlock(MOCK_USER_ID, 1L, 200L));
+    }
+
+    @Test
+    @DisplayName("사물함 열기 요청 - 보관 실패 (습득물이 아닌 경우)")
+    void requestUnlock_Storage_Fail_NotFoundType() {
+        // given
+        validItem.setType(ItemType.LOST); // 분실물로 변경
+        when(userRepository.findById(MOCK_USER_ID)).thenReturn(Optional.of(mockUser));
+        when(lockerRepository.findById(1L)).thenReturn(Optional.of(emptyLocker));
+        when(itemRepository.findById(200L)).thenReturn(Optional.of(validItem));
+
+        // when & then
+        assertThrows(BadRequestException.class,
+                () -> lockerService.requestUnlock(MOCK_USER_ID, 1L, 200L));
+    }
+
+    @Test
+    @DisplayName("사물함 열기 요청 - 회수 (채팅을 통해 반환이 확정된 분실자)")
+    void requestUnlock_Retrieval_Success_ByChatOwner() {
+        // given
+        when(userRepository.findById(MOCK_USER_ID)).thenReturn(Optional.of(mockUser));
+        when(lockerRepository.findById(2L)).thenReturn(Optional.of(fullLocker));
+
+        when(chatRoomRepository.existsByItemAndOwnerIdAndStatus(storedItem, MOCK_USER_ID, ChatRoomStatus.RESOLVED_RETURNED))
+                .thenReturn(true);
+
+        when(commandRepository.save(any(LockerCommand.class))).thenAnswer(i -> i.getArgument(0));
+
+        // when
+        LockerCommand command = lockerService.requestUnlock(MOCK_USER_ID, 2L, null);
+
+        // then
+        assertEquals(LockerStatus.EMPTY, fullLocker.getStatus());
+        assertNull(fullLocker.getCurrentItem());
+        assertEquals(ItemStatus.RETURNED, storedItem.getStatus());
+        assertNotNull(storedItem.getReturnedAt());
+
+        assertEquals(LockerCommandType.OPEN, command.getCommand());
+        verify(commandRepository, times(1)).save(any(LockerCommand.class));
+    }
+    @Test
+    @DisplayName("사물함 열기 요청 - 회수 (매칭이 확정된 물품 소유자)")
+    void requestUnlock_Retrieval_Success_ByMatchedOwner() {
+        // given
+        storedItem.setReporter(otherUser); // 물건을 넣은 사람은 otherUser
+        when(userRepository.findById(MOCK_USER_ID)).thenReturn(Optional.of(mockUser));
+        when(lockerRepository.findById(2L)).thenReturn(Optional.of(fullLocker));
+
+        // 권한 체크 모킹: mockUser가 해당 물품과 CONFIRMED 상태로 매칭됨
+        when(itemMatchRepository.existsByFoundItemAndLostItem_Reporter_IdAndStatus(storedItem, MOCK_USER_ID, MatchStatus.CONFIRMED))
+                .thenReturn(true);
+        when(commandRepository.save(any(LockerCommand.class))).thenAnswer(i -> i.getArgument(0));
+
+        // when
+        LockerCommand command = lockerService.requestUnlock(MOCK_USER_ID, 2L, null);
+
+        // then
+        assertEquals(LockerStatus.EMPTY, fullLocker.getStatus());
+        assertEquals(ItemStatus.RETURNED, storedItem.getStatus());
+    }
+
+    @Test
+    @DisplayName("사물함 열기 요청 - 회수 실패 (권한 없음)")
+    void requestUnlock_Retrieval_Fail_NoPermission() {
+        // given
+        storedItem.setReporter(otherUser); // 물건을 넣은 사람은 otherUser
+        when(userRepository.findById(MOCK_USER_ID)).thenReturn(Optional.of(mockUser));
+        when(lockerRepository.findById(2L)).thenReturn(Optional.of(fullLocker));
+
+        // 매칭된 기록 없음
+        when(itemMatchRepository.existsByFoundItemAndLostItem_Reporter_IdAndStatus(storedItem, MOCK_USER_ID, MatchStatus.CONFIRMED))
+                .thenReturn(false);
+        // 채팅방을 통한 권한 없음 (Mock의 기본 반환값이 false이므로 생략해도 되지만 명시성을 위해 남길 수 있습니다)
+
+        // when & then
+        assertThrows(ForbiddenException.class,
+                () -> lockerService.requestUnlock(MOCK_USER_ID, 2L, null));
+    }
+
+    @Test
+    @DisplayName("사물함 점검 중 예외 발생")
+    void requestUnlock_Fail_Maintenance() {
+        // given
+        emptyLocker.setStatus(LockerStatus.MAINTENANCE);
+        when(userRepository.findById(MOCK_USER_ID)).thenReturn(Optional.of(mockUser));
+        when(lockerRepository.findById(1L)).thenReturn(Optional.of(emptyLocker));
+
+        // when & then
+        assertThrows(BadRequestException.class,
+                () -> lockerService.requestUnlock(MOCK_USER_ID, 1L, 200L));
+    }
+
+    @Test
+    @DisplayName("사물함 닫기 요청 - 성공")
+    void requestLock_Success() {
+        // given
+        when(userRepository.findById(MOCK_USER_ID)).thenReturn(Optional.of(mockUser));
+        when(lockerRepository.findById(1L)).thenReturn(Optional.of(emptyLocker));
+
+        // 최근에 문을 연 기록 (본인이 열었음)
+        LockerCommand lastOpenCmd = LockerCommand.builder()
+                .issuedBy(mockUser)
+                .command(LockerCommandType.OPEN)
+                .build();
+        when(commandRepository.findFirstByLocker_IdAndCommandOrderByCreatedAtDesc(1L, LockerCommandType.OPEN))
+                .thenReturn(Optional.of(lastOpenCmd));
+
+        when(commandRepository.save(any(LockerCommand.class))).thenAnswer(i -> i.getArgument(0));
+
+        // when
+        LockerCommand command = lockerService.requestLock(MOCK_USER_ID, 1L);
+
+        // then
+        assertEquals(LockerCommandType.CLOSE, command.getCommand());
+        verify(commandRepository, times(1)).save(any(LockerCommand.class));
+    }
+
+    @Test
+    @DisplayName("사물함 닫기 요청 - 실패 (자신이 열지 않은 사물함)")
+    void requestLock_Fail_NotIssuer() {
+        // given
+        when(userRepository.findById(MOCK_USER_ID)).thenReturn(Optional.of(mockUser));
+        when(lockerRepository.findById(1L)).thenReturn(Optional.of(emptyLocker));
+
+        // 최근에 문을 연 기록 (타인이 열었음)
+        LockerCommand lastOpenCmd = LockerCommand.builder()
+                .issuedBy(otherUser)
+                .command(LockerCommandType.OPEN)
+                .build();
+        when(commandRepository.findFirstByLocker_IdAndCommandOrderByCreatedAtDesc(1L, LockerCommandType.OPEN))
+                .thenReturn(Optional.of(lastOpenCmd));
+
+        // when & then
+        assertThrows(ForbiddenException.class,
+                () -> lockerService.requestLock(MOCK_USER_ID, 1L));
+    }
+
+    @Test
+    @DisplayName("명령 폴링 (Poll) - 성공 시 CONSUMED 상태로 변경")
+    void pollNextCommand_Success() {
+        // given
+        LockerCommand pendingCommand = LockerCommand.builder()
+                .id(10L)
+                .locker(emptyLocker)
+                .command(LockerCommandType.OPEN)
+                .status(LockerCommandStatus.PENDING)
+                .build();
+
+        when(commandRepository.findFirstByLocker_IdAndStatusOrderByCreatedAtAsc(1L, LockerCommandStatus.PENDING))
+                .thenReturn(Optional.of(pendingCommand));
+
+        // when
+        Optional<LockerCommand> result = lockerService.pollNextCommand(1L);
+
+        // then
+        assertTrue(result.isPresent());
+        assertEquals(LockerCommandStatus.CONSUMED, result.get().getStatus());
+        assertNotNull(result.get().getConsumedAt());
+    }
+
+    @Test
+    @DisplayName("명령 완료 처리 (Ack) - 성공 시 COMPLETED 상태로 변경")
+    void ackCommand_Success() {
+        // given
+        LockerCommand consumedCommand = LockerCommand.builder()
+                .id(10L)
+                .locker(emptyLocker) // lockerId = 1L
+                .status(LockerCommandStatus.CONSUMED)
+                .build();
+
+        when(commandRepository.findById(10L)).thenReturn(Optional.of(consumedCommand));
+
+        // when
+        lockerService.ackCommand(1L, 10L);
+
+        // then
+        assertEquals(LockerCommandStatus.COMPLETED, consumedCommand.getStatus());
+        assertNotNull(consumedCommand.getCompletedAt());
+    }
+
+    @Test
+    @DisplayName("명령 완료 처리 (Ack) - 다른 사물함의 명령인 경우 예외 발생")
+    void ackCommand_Fail_LockerMismatch() {
+        // given
+        LockerCommand consumedCommand = LockerCommand.builder()
+                .id(10L)
+                .locker(fullLocker) // lockerId = 2L
+                .build();
+
+        when(commandRepository.findById(10L)).thenReturn(Optional.of(consumedCommand));
+
+        // when & then
+        assertThrows(BadRequestException.class,
+                () -> lockerService.ackCommand(1L, 10L));
+    }
+}

--- a/src/test/java/com/zoopick/server/service/ProfileServiceTest.java
+++ b/src/test/java/com/zoopick/server/service/ProfileServiceTest.java
@@ -1,0 +1,127 @@
+package com.zoopick.server.service;
+
+import com.zoopick.server.dto.profile.ProfileSummaryResponse;
+import com.zoopick.server.dto.profile.ProfileUpdateRequest;
+import com.zoopick.server.entity.User;
+import com.zoopick.server.repository.ChatRoomRepository;
+import com.zoopick.server.repository.ItemPostRepository;
+import com.zoopick.server.repository.NotificationRepository;
+import com.zoopick.server.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceTest {
+
+    @InjectMocks
+    private ProfileService profileService;
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private ItemPostRepository itemPostRepository;
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    private User user;
+    private final String EMAIL = "test@mju.ac.kr";
+    private final Long USER_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        // User 엔티티 모킹 (실제 엔티티의 @Builder 사용 가정)
+        user = User.builder()
+                .id(USER_ID)
+                .schoolEmail(EMAIL)
+                .nickname("기존닉네임")
+                .department("컴퓨터공학과")
+                .build();
+    }
+
+    @Test
+    @DisplayName("프로필 요약 조회 - 성공 (각종 카운트 정상 집계)")
+    void getProfileSummary_Success() {
+        // given
+        when(userRepository.findBySchoolEmailOrThrow(EMAIL)).thenReturn(user);
+        when(itemPostRepository.countByUserId(USER_ID)).thenReturn(5L);
+        when(chatRoomRepository.countByOwnerIdOrFinderId(USER_ID, USER_ID)).thenReturn(3L);
+        when(notificationRepository.countByUserIdAndReadAtIsNull(USER_ID)).thenReturn(2L);
+
+        // when
+        ProfileSummaryResponse response = profileService.getProfileSummary(EMAIL);
+
+        // then
+        assertNotNull(response);
+        assertEquals("기존닉네임", response.nickname());
+        assertEquals("컴퓨터공학과", response.department());
+        assertEquals(5L, response.postCount());
+        assertEquals(3L, response.chatRoomCount());
+        assertEquals(2L, response.unreadNotificationCount());
+
+        verify(itemPostRepository, times(1)).countByUserId(USER_ID);
+        verify(chatRoomRepository, times(1)).countByOwnerIdOrFinderId(USER_ID, USER_ID);
+        verify(notificationRepository, times(1)).countByUserIdAndReadAtIsNull(USER_ID);
+    }
+
+    @Test
+    @DisplayName("프로필 업데이트 - 성공 (닉네임 변경 없음)")
+    void updateProfile_Success_SameNickname() {
+        // given
+        ProfileUpdateRequest request = new ProfileUpdateRequest("기존닉네임", "소프트웨어학과");
+        when(userRepository.findBySchoolEmailOrThrow(EMAIL)).thenReturn(user);
+
+        // when
+        profileService.updateProfile(EMAIL, request);
+
+        // then
+        // 닉네임이 같으므로 중복 체크 로직(existsByNickname)이 호출되지 않아야 함
+        verify(userRepository, never()).existsByNickname(anyString());
+        assertEquals("소프트웨어학과", user.getDepartment());
+    }
+
+    @Test
+    @DisplayName("프로필 업데이트 - 성공 (닉네임 변경 및 중복 없음)")
+    void updateProfile_Success_NewNickname() {
+        // given
+        ProfileUpdateRequest request = new ProfileUpdateRequest("새로운닉네임", "소프트웨어학과");
+        when(userRepository.findBySchoolEmailOrThrow(EMAIL)).thenReturn(user);
+        when(userRepository.existsByNickname("새로운닉네임")).thenReturn(false);
+
+        // when
+        profileService.updateProfile(EMAIL, request);
+
+        // then
+        verify(userRepository, times(1)).existsByNickname("새로운닉네임");
+        assertEquals("새로운닉네임", user.getNickname());
+        assertEquals("소프트웨어학과", user.getDepartment());
+    }
+
+    @Test
+    @DisplayName("프로필 업데이트 - 실패 (변경하려는 닉네임이 이미 존재함)")
+    void updateProfile_Fail_NicknameAlreadyExists() {
+        // given
+        ProfileUpdateRequest request = new ProfileUpdateRequest("중복닉네임", "컴퓨터공학과");
+        when(userRepository.findBySchoolEmailOrThrow(EMAIL)).thenReturn(user);
+        when(userRepository.existsByNickname("중복닉네임")).thenReturn(true);
+
+        // when & then
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> profileService.updateProfile(EMAIL, request));
+
+        assertEquals("이미 존재하는 닉네임입니다.", exception.getMessage());
+
+        // 정보가 업데이트 되지 않았는지 검증
+        assertEquals("기존닉네임", user.getNickname());
+    }
+}

--- a/src/test/java/com/zoopick/server/service/TimetableServiceTest.java
+++ b/src/test/java/com/zoopick/server/service/TimetableServiceTest.java
@@ -1,0 +1,273 @@
+package com.zoopick.server.service;
+
+import com.zoopick.server.dto.timetable.CreateTimetableRequest;
+import com.zoopick.server.dto.timetable.TimetableCourseRecord;
+import com.zoopick.server.dto.timetable.TimetableGroupResponse;
+import com.zoopick.server.dto.timetable.TimetableSyncRequest;
+import com.zoopick.server.entity.*;
+import com.zoopick.server.exception.BadRequestException;
+import com.zoopick.server.exception.DataNotFoundException;
+import com.zoopick.server.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TimetableServiceTest {
+
+    @InjectMocks
+    private TimetableService timetableService;
+
+    @Mock private TimetableGroupRepository groupRepository;
+    @Mock private TimetableRepository timetableRepository;
+    @Mock private CourseRepository courseRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private CourseScheduleRepository courseScheduleRepository;
+
+    private User user;
+    private TimetableGroup group;
+    private Course course1;
+    private Course course2;
+
+    private final String EMAIL = "test@mju.ac.kr";
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder().id(1L).schoolEmail(EMAIL).build();
+
+        group = TimetableGroup.builder()
+                .id(10L)
+                .user(user)
+                .name("1학기 시간표")
+                .year(2026)
+                .semester(1)
+                .isPrimary(true)
+                .build();
+
+        Building building = Building.builder().code("S1").name("함박관").build();
+        Room room = Room.builder().name("S1111").building(building).build();
+
+        course1 = Course.builder().id(101L).courseName("글쓰기").room(room).build();
+        course2 = Course.builder().id(102L).courseName("영어1").room(room).build();
+    }
+
+    @Test
+    @DisplayName("특정 학기 시간표 목록 조회 - 성공")
+    void getTimetableGroups_Success() {
+        // given
+        when(userRepository.findBySchoolEmailOrThrow(EMAIL)).thenReturn(user);
+        when(groupRepository.findAllByUserAndYearAndSemester(user, 2026, 1)).thenReturn(List.of(group));
+
+        // when
+        List<TimetableGroupResponse> responses = timetableService.getTimetableGroups(EMAIL, 2026, 1);
+
+        // then
+        assertEquals(1, responses.size());
+        assertEquals("1학기 시간표", responses.get(0).name());
+    }
+
+    @Test
+    @DisplayName("내 모든 시간표 목록 조회 - 성공")
+    void getMyTimetableGroups_Success() {
+        // given
+        when(userRepository.findBySchoolEmailOrThrow(EMAIL)).thenReturn(user);
+        when(groupRepository.findAllByUserOrderByYearDescSemesterDesc(user)).thenReturn(List.of(group));
+
+        // when
+        List<TimetableGroupResponse> responses = timetableService.getMyTimetableGroups(EMAIL);
+
+        // then
+        assertEquals(1, responses.size());
+        assertEquals(2026, responses.get(0).year());
+    }
+
+    @Test
+    @DisplayName("시간표 생성 - 해당 유저의 첫 시간표라면 Primary로 설정됨")
+    void createTimetable_FirstGroup_BecomesPrimary() {
+        // given
+        CreateTimetableRequest request = new CreateTimetableRequest("내 시간표", 2026, 1);
+
+        when(userRepository.findBySchoolEmailOrThrow(EMAIL)).thenReturn(user);
+
+        when(groupRepository.findAllByUserOrderByYearDescSemesterDesc(user)).thenReturn(List.of());
+
+        when(groupRepository.save(any(TimetableGroup.class))).thenAnswer(i -> i.getArgument(0));
+
+        // when
+        TimetableGroupResponse response = timetableService.createTimetable(EMAIL, request);
+
+        // then
+        assertTrue(response.isPrimary());
+        verify(groupRepository, times(1)).save(any(TimetableGroup.class));
+    }
+
+    @Test
+    @DisplayName("시간표 생성 - 이미 시간표가 존재하면 Primary가 아님")
+    void createTimetable_AdditionalGroup_NotPrimary() {
+        // given
+        CreateTimetableRequest request = new CreateTimetableRequest("서브 시간표", 2026, 1);
+
+        when(userRepository.findBySchoolEmailOrThrow(EMAIL)).thenReturn(user);
+
+        when(groupRepository.findAllByUserOrderByYearDescSemesterDesc(user)).thenReturn(List.of(group));
+
+        when(groupRepository.save(any(TimetableGroup.class))).thenAnswer(i -> i.getArgument(0));
+
+        // when
+        TimetableGroupResponse response = timetableService.createTimetable(EMAIL, request);
+
+        // then
+        assertFalse(response.isPrimary());
+    }
+
+    @Test
+    @DisplayName("기본 시간표 조회 - 없을 경우 null 반환")
+    void getPrimaryTimetableGroup_NotFound() {
+        // given
+        when(userRepository.findBySchoolEmailOrThrow(EMAIL)).thenReturn(user);
+        when(groupRepository.findByUserAndIsPrimaryTrue(user)).thenReturn(Optional.empty());
+
+        // when
+        TimetableGroupResponse response = timetableService.getPrimaryTimetableGroup(EMAIL);
+
+        assertNull(response);
+    }
+
+    @Test
+    @DisplayName("시간표 상세 조회 - 성공")
+    void getTimetableDetails_Success() {
+        // given
+        Timetable t1 = Timetable.builder().course(course1).color("#FFF").build();
+        CourseSchedule schedule1 = mock(CourseSchedule.class);
+        when(schedule1.getCourse()).thenReturn(course1);
+
+        when(userRepository.findBySchoolEmailOrThrow(EMAIL)).thenReturn(user);
+        when(groupRepository.findByIdAndUser(10L, user)).thenReturn(Optional.of(group));
+        when(timetableRepository.findAllByTimetableGroup(group)).thenReturn(List.of(t1));
+        when(courseScheduleRepository.findAllByCourseIn(List.of(course1))).thenReturn(List.of(schedule1));
+
+        // when
+        List<TimetableCourseRecord> details = timetableService.getTimetableDetails(EMAIL, 10L);
+
+        // then
+        assertEquals(1, details.size());
+        assertEquals(course1.getId(), details.get(0).getCourseId());
+        assertEquals("함박관", details.get(0).getBuildingName());
+    }
+
+    @Test
+    @DisplayName("시간표 동기화 - 성공 (시간표 덮어쓰기 및 중복 없음)")
+    void syncTimetable_Success() {
+        // given
+        TimetableSyncRequest.CourseColorRequest colorReq1 = new TimetableSyncRequest.CourseColorRequest(101L, "#FFFFFF");
+        TimetableSyncRequest.CourseColorRequest colorReq2 = new TimetableSyncRequest.CourseColorRequest(102L, "#000000");
+        TimetableSyncRequest request = new TimetableSyncRequest(List.of(colorReq1, colorReq2));
+
+        when(userRepository.findBySchoolEmailOrThrow(EMAIL)).thenReturn(user);
+        when(groupRepository.findByIdAndUser(10L, user)).thenReturn(Optional.of(group));
+
+        // 다건 조회 모킹
+        when(courseRepository.findAllById(anyList())).thenReturn(List.of(course1, course2));
+
+        CourseSchedule schedule1 = mock(CourseSchedule.class);
+        when(schedule1.getCourse()).thenReturn(course1);
+        CourseSchedule schedule2 = mock(CourseSchedule.class);
+        when(schedule2.getCourse()).thenReturn(course2);
+
+        // 시간 겹치지 않음 모킹
+        when(schedule1.hasCollisionWith(schedule2)).thenReturn(false);
+        when(courseScheduleRepository.findAllByCourseIdIn(anyList())).thenReturn(List.of(schedule1, schedule2));
+
+        // when
+        timetableService.syncTimetable(EMAIL, 10L, request);
+
+        // then
+        verify(timetableRepository, times(1)).deleteAllByTimetableGroup(group);
+        verify(timetableRepository, times(1)).flush();
+        verify(timetableRepository, times(1)).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("시간표 동기화 - 강의 시간 중복 시 예외 발생")
+    void syncTimetable_Fail_Overlap() {
+        // given
+        TimetableSyncRequest.CourseColorRequest colorReq1 = new TimetableSyncRequest.CourseColorRequest(101L, "#FFFFFF");
+        TimetableSyncRequest.CourseColorRequest colorReq2 = new TimetableSyncRequest.CourseColorRequest(102L, "#000000");
+        TimetableSyncRequest request = new TimetableSyncRequest(List.of(colorReq1, colorReq2));
+
+        when(userRepository.findBySchoolEmailOrThrow(EMAIL)).thenReturn(user);
+        when(groupRepository.findByIdAndUser(10L, user)).thenReturn(Optional.of(group));
+
+        // 다건 조회 모킹
+        when(courseRepository.findAllById(anyList())).thenReturn(List.of(course1, course2));
+
+        CourseSchedule schedule1 = mock(CourseSchedule.class);
+        when(schedule1.getCourse()).thenReturn(course1);
+        CourseSchedule schedule2 = mock(CourseSchedule.class);
+        when(schedule2.getCourse()).thenReturn(course2);
+
+        // 강의 시간이 겹침을 명시적으로 모킹
+        when(schedule1.hasCollisionWith(schedule2)).thenReturn(true);
+        when(courseScheduleRepository.findAllByCourseIdIn(anyList())).thenReturn(List.of(schedule1, schedule2));
+
+        // when & then
+        BadRequestException exception = assertThrows(BadRequestException.class,
+                () -> timetableService.syncTimetable(EMAIL, 10L, request));
+        assertTrue(exception.getMessage().contains("강의 시간이 겹칩니다"));
+
+        verify(timetableRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("시간표 삭제 - 성공")
+    void deleteTimetableGroup_Success() {
+        // given
+        when(userRepository.findBySchoolEmailOrThrow(EMAIL)).thenReturn(user);
+        when(groupRepository.findByIdAndUser(10L, user)).thenReturn(Optional.of(group));
+
+        // when
+        timetableService.deleteTimetableGroup(EMAIL, 10L);
+
+        // then
+        verify(timetableRepository, times(1)).deleteAllByTimetableGroup(group);
+        verify(groupRepository, times(1)).delete(group);
+    }
+
+    @Test
+    @DisplayName("강의 검색 (페이지네이션) - 성공")
+    void searchCourses_Success() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Course> coursePage = new PageImpl<>(List.of(course1, course2), pageable, 2);
+
+        CourseSchedule schedule1 = mock(CourseSchedule.class);
+        when(schedule1.getCourse()).thenReturn(course1);
+
+        when(courseRepository.searchCourses(2026, 1, "데이터", pageable)).thenReturn(coursePage);
+        when(courseScheduleRepository.findAllByCourseIn(anyList())).thenReturn(List.of(schedule1));
+
+        // when
+        Page<TimetableCourseRecord> result = timetableService.searchCourses(2026, 1, "데이터", pageable);
+
+        // then
+        assertEquals(2, result.getContent().size());
+        assertEquals(course1.getId(), result.getContent().get(0).getCourseId());
+        assertEquals("함박관", result.getContent().get(0).getBuildingName());
+    }
+}

--- a/src/test/java/com/zoopick/server/service/TokenValidationServiceTest.java
+++ b/src/test/java/com/zoopick/server/service/TokenValidationServiceTest.java
@@ -1,0 +1,133 @@
+package com.zoopick.server.service;
+
+import com.zoopick.server.exception.AccessTokenException;
+import com.zoopick.server.security.JwtUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TokenValidationServiceTest {
+
+    @InjectMocks
+    private TokenValidationService tokenValidationService;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Test
+    @DisplayName("토큰 무효화 - 만료 시간이 남아있다면 Redis에 블랙리스트 등록")
+    void invalidateToken_Success() throws Exception {
+        // given
+        String token = "valid.access.token";
+        long remainingTime = 10000L; // 10초
+
+        given(jwtUtil.getRemainingExpirationTime(token)).willReturn(remainingTime);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        // when
+        tokenValidationService.invalidateToken(token);
+
+        // then
+        verify(valueOperations).set(token, "logout", remainingTime, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    @DisplayName("토큰 무효화 - 이미 만료 시간이 지났다면 Redis에 저장하지 않고 무시")
+    void invalidateToken_IgnoreIfExpired() throws Exception {
+        // given
+        String token = "expired.access.token";
+        long remainingTime = 0L; // 만료됨
+
+        given(jwtUtil.getRemainingExpirationTime(token)).willReturn(remainingTime);
+
+        // when
+        tokenValidationService.invalidateToken(token);
+
+        // then
+        // opsForValue().set()이 호출되지 않았는지 검증
+        verify(redisTemplate, never()).opsForValue();
+    }
+
+    @Test
+    @DisplayName("토큰 검증 (Throw) - 블랙리스트에 없고 유효하면 true 반환")
+    void validateTokenOrThrow_Success() {
+        // given
+        String token = "valid.access.token";
+
+        given(redisTemplate.hasKey(token)).willReturn(false); // 로그아웃 안 된 토큰
+        given(jwtUtil.isExpirationValid(token)).willReturn(true); // 만료 안 된 토큰
+
+        // when
+        boolean isValid = tokenValidationService.validateTokenOrThrow(token);
+
+        // then
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    @DisplayName("토큰 검증 (Throw) - Redis 블랙리스트에 존재하면 false 반환")
+    void validateTokenOrThrow_Fail_Blacklisted() {
+        // given
+        String token = "logout.access.token";
+
+        given(redisTemplate.hasKey(token)).willReturn(true); // 로그아웃(블랙리스트) 처리됨
+
+        // when
+        boolean isValid = tokenValidationService.validateTokenOrThrow(token);
+
+        // then
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    @DisplayName("토큰 예외 없는 검증 - 유효한 토큰일 때 true 반환")
+    void validateToken_Success() {
+        // given
+        String token = "valid.access.token";
+
+        given(redisTemplate.hasKey(token)).willReturn(false);
+        given(jwtUtil.isExpirationValid(token)).willReturn(true);
+
+        // when
+        boolean isValid = tokenValidationService.validateToken(token);
+
+        // then
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    @DisplayName("토큰 예외 없는 검증 - 예외가 발생하면 예외를 잡아서 false 반환")
+    void validateToken_Fail_ReturnsFalseOnException() {
+        // given
+        String token = "invalid.access.token";
+
+        given(redisTemplate.hasKey(token)).willReturn(false);
+        // JwtUtil에서 검증 실패로 AccessTokenException이 발생한다고 가정
+        given(jwtUtil.isExpirationValid(token)).willThrow(new AccessTokenException("Invalid token"));
+
+        // when
+        boolean isValid = tokenValidationService.validateToken(token);
+
+        // then
+        assertThat(isValid).isFalse();
+    }
+}

--- a/src/test/java/com/zoopick/server/service/notification/NotificationServiceTest.java
+++ b/src/test/java/com/zoopick/server/service/notification/NotificationServiceTest.java
@@ -1,0 +1,140 @@
+package com.zoopick.server.service.notification;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zoopick.server.dto.notification.ChangeReadStatusResult;
+import com.zoopick.server.entity.NotificationType;
+import com.zoopick.server.entity.User;
+import com.zoopick.server.entity.ZoopickNotification;
+import com.zoopick.server.mapper.notification.NotificationMapper;
+import com.zoopick.server.mapper.notification.NotificationPayloadMapper;
+import com.zoopick.server.repository.NotificationRepository;
+import com.zoopick.server.repository.UserRepository;
+import com.zoopick.server.service.notification.payload.NotificationPayload;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private NotificationMapper notificationMapper;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private NotificationPayloadMapper notificationPayloadMapper;
+
+    @Test
+    @DisplayName("FCM 토큰 등록 - 성공")
+    void register_Success() {
+        // given
+        long userId = 1L;
+        String fcmToken = "test_fcm_token";
+        User user = User.builder().id(userId).build();
+
+        given(userRepository.findByIdOrThrow(userId)).willReturn(user);
+
+        // when
+        notificationService.register(userId, fcmToken);
+
+        // then
+        assertThat(user.getFcmToken()).isEqualTo(fcmToken);
+    }
+
+    @Test
+    @DisplayName("알림 전송 - 성공 (이벤트 발행 검증)")
+    void send_Success() {
+        // given
+        User user = User.builder().id(1L).fcmToken("valid_token").build();
+
+        NotificationPayload payloadMock = mock(NotificationPayload.class);
+        lenient().when(payloadMock.toMap()).thenReturn(Map.of());
+        lenient().when(payloadMock.type()).thenReturn(NotificationType.values()[0]);
+
+        SendNotificationCommand command = new SendNotificationCommand("제목", "내용", payloadMock);
+        ZoopickNotification notification = ZoopickNotification.builder().id(100L).user(user).build();
+
+        given(notificationMapper.toZoopickNotification(user, command)).willReturn(notification);
+        given(notificationRepository.save(any(ZoopickNotification.class))).willReturn(notification);
+
+        // when
+        String result = notificationService.send(user, command);
+
+        // then
+        assertThat(result).isEqualTo("100");
+        verify(notificationRepository, times(1)).save(any(ZoopickNotification.class));
+        verify(eventPublisher, times(1)).publishEvent(any(Object.class));
+    }
+
+    @Test
+    @DisplayName("알림 전송 - FCM 토큰이 없는 경우 예외 없이 DB에 저장되고 이벤트가 발행된다")
+    void send_Success_WithoutFcmToken() {
+        // given
+        User user = User.builder().id(1L).schoolEmail("test@mju.ac.kr").fcmToken(null).build();
+
+        NotificationPayload payloadMock = mock(NotificationPayload.class);
+        lenient().when(payloadMock.type()).thenReturn(NotificationType.values()[0]);
+        lenient().when(payloadMock.toMap()).thenReturn(Map.of());
+
+        SendNotificationCommand command = new SendNotificationCommand("제목", "내용", payloadMock);
+        ZoopickNotification mockNotification = ZoopickNotification.builder().id(100L).user(user).build();
+
+        given(notificationMapper.toZoopickNotification(user, command)).willReturn(mockNotification);
+        given(notificationRepository.save(any(ZoopickNotification.class))).willReturn(mockNotification);
+
+        // when
+        String result = notificationService.send(user, command);
+
+        // then
+        assertThat(result).isEqualTo("100");
+        verify(notificationRepository, times(1)).save(any(ZoopickNotification.class));
+        verify(eventPublisher, times(1)).publishEvent(any(Object.class));
+    }
+
+    @Test
+    @DisplayName("알림 읽음 처리 - 성공")
+    void markAsRead_Success() {
+        // given
+        long userId = 1L;
+        User user = User.builder().id(userId).build();
+        ZoopickNotification notification1 = ZoopickNotification.builder().id(10L).user(user).build();
+        ZoopickNotification notification2 = ZoopickNotification.builder().id(11L).user(user).build();
+
+        List<Long> notificationIds = List.of(10L, 11L);
+        given(notificationRepository.findAllById(notificationIds)).willReturn(List.of(notification1, notification2));
+
+        // when
+        ChangeReadStatusResult result = notificationService.markAsRead(userId, notificationIds);
+
+        // then
+        assertThat(result.getSucceedIds()).containsExactly(10L, 11L);
+        assertThat(notification1.getReadAt()).isNotNull();
+        assertThat(notification2.getReadAt()).isNotNull();
+    }
+}


### PR DESCRIPTION
**#테스트 실행 흐름**

테스트 코드를 Mockito와 JUnit5를 활용하여 BDD(Behavior-Driven Development) 패턴인 Given-When-Then 흐름으로 일관되게 작성하였습니다.

Setup (https://github.com/beforeeach): 각 테스트가 실행되기 전 필요한 더미 데이터(User, Item, ChatRoom 등)를 초기화하고, https://github.com/value 등으로 주입받아야 하는 필드는 ReflectionTestUtils를 이용해 세팅합니다.

Given (준비): @Mock으로 생성된 가짜 객체(Repository, Mapper 등)들이 특정 상황에서 어떻게 동작해야 하는지(when().thenReturn(), given().willReturn()) 정의합니다.

When (실행): 실제 테스트하고자 하는 Service 클래스의 메서드를 호출합니다.

Then (검증):

메서드의 반환값이 기대한 값과 일치하는지(assertEquals, assertThat) 확인합니다.

비정상적인 요청에 대해 적절한 예외(BadRequestException, ForbiddenException 등)가 발생하는지 확인합니다.

내부적으로 특정 메서드(ex: repository.save(), eventPublisher.publishEvent())가 올바르게 호출되었는지 검증합니다.
<br>

**#구성 요소**

인증 및 보안 (Auth & TokenValidation)

로그인, 토큰 발급 및 재발급 등 핵심 인증 로직 검증 (AuthServiceTest).
Redis를 활용한 JWT 토큰 블랙리스트(로그아웃) 처리 및 토큰 만료 예외 검증 (TokenValidationService).

알림 및 이메일 (Notification & Email)

FCM 토큰 등록 및 알림 전송 (토큰이 없어도 DB 저장 및 이벤트 정상 발행 여부 확인).
JavaMailSender를 활용한 MimeMessage 인증 메일 발송 로직 검증.

채팅 (ChatRoom)

본인에게 채팅 걸기, 닫힌 방에 메시지 전송 등 예외 상황 차단 로직 검증.
정상적인 메시지 전송 시 DB 저장과 함께 상대방에게 알림이 발송되는지 확인.
파일 처리 (Image)
MockMultipartFile을 이용한 파일 업로드 시뮬레이션.
빈 파일, 허용되지 않은 Content-Type, 확장자 누락에 대한 예외 처리 검증.
분실물 매칭 (ItemMatch)
Vector 유사도(Score) 기반 자동 매칭 알고리즘 임계치(similarityThreshold) 검증.
보관함(Locker) 기반과 채팅(Chat) 기반 수동 매칭 분기 처리 및 매칭 확정/거절 기능 확인.

게시글 (ItemPost)

분실물/습득물 게시글 생성 시 상태 변경 및 이벤트 발행 검증.
페이지네이션이 적용된 게시글 목록 및 단일 게시글 조회 기능 확인.

사물함 제어 (Locker)

보관 및 회수 시 사용자 권한(신고자 본인, 매칭 확정자 등) 통제 검증.
사물함 하드웨어와의 통신을 위한 명령(Command) 폴링(Poll) 및 응답(Ack) 상태 변경(Pending -> Consumed -> Completed) 로직 확인.

시간표 (Timetable)

첫 시간표 생성 시 기본(Primary) 자동 설정 검증.
강의 시간표 동기화 시 강의 시간 중복(Collision) 검사 예외 로직 확인.

유저 프로필 (Profile)

각종 카운트(작성 글, 채팅방, 안 읽은 알림) 정상 집계 확인.
프로필 업데이트 시 닉네임 중복 체크 방어 로직 검증.
<br>

**#의존성 및 기타 변경 사항**

테스트 환경 구성을 위한 spring-boot-starter-test, mockito 관련 의존성 활용.

발생 가능한 엣지 케이스(권한 없음, 중복, 논리적 오류 등)에 예외 처리(Exception) 검증을 통해 서비스 안정성 강화
<br>
**🛠빌드 에러 수정**

ChatRoomServiceTest 수정: ChatRoomRepository에 존재하지 않는 메서드 호출로 인한 컴파일 에러와 Mockito의 엄격한 스터빙(UnnecessaryStubbingException, PotentialStubbingProblem) 에러를 분석했습니다. 실제 서비스 로직에서 호출하는 findOpenByParticipantAndItem 메서드로 레포지토리 모킹(Mocking)을 정확히 일치시켰습니다.

ItemMatchServiceTest 수정: 테스트 환경에서 누락되었던 MatchConfig 및 ItemPostRepository 의존성을 Mock하고, 실제 비즈니스 흐름과 일치하지 않던 DTO 반환 방식을 수정하여 안정성을 확보했습니다.

LockerServiceTest 및 TimetableServiceTest 수정:  LockerService 내부의 회수 권한 검증 로직을 만족하도록 ChatRoomRepository 모킹을 추가하고 테스트 시나리오를 수정했습니다.

TimetableService에서 학기 시간표 판단 시 실제 호출하는 메서드(findAllByUserOrderByYearDescSemesterDesc)로 일치시키고, 예외가 아닌 null을 반환하는 구조에 맞게 검증 방식(assertNull)을 수정했습니다