### PR TITLE
Fix:  Resolver 메서드 변경

### DIFF
--- a/src/test/java/com/zoopick/server/service/CctvMatchServiceTest.java
+++ b/src/test/java/com/zoopick/server/service/CctvMatchServiceTest.java
@@ -1,7 +1,6 @@
 package com.zoopick.server.service;
 
 import com.zoopick.server.config.MatchConfig;
-import com.zoopick.server.dto.match.CctvMatchCriteria;
 import com.zoopick.server.dto.match.CreateCctvMatchEvent;
 import com.zoopick.server.dto.match.SimilarItemProjection;
 import com.zoopick.server.entity.*;
@@ -158,27 +157,9 @@ class CctvMatchServiceTest {
             given(cctvDetectionMatchRepository.findLostItems(any(), any(), any(), anyFloat()))
                     .willReturn(List.of(projection));
             given(itemPostRepository.findAllByItemIdsWithItem(any())).willReturn(List.of(itemPost));
-            given(cctvMatchCriteriaResolver.resolve(lostItem))
-                    .willReturn(new CctvMatchCriteria(List.of(10L), LocalDateTime.now().minusHours(3)));
+            given(cctvMatchCriteriaResolver.resolveRoomIds(lostItem))
+                    .willReturn(List.of(10L));
             given(cctvDetectionMatchRepository.existsByCctvDetectionAndItem(cctvDetection, lostItem)).willReturn(true);
-
-            cctvMatchService.matchCctvToLostItems(1L);
-
-            then(cctvDetectionMatchRepository).should(never()).save(any());
-        }
-
-        @Test
-        @DisplayName("검출 시각이 기준 시작시간 이전이면 해당 아이템은 매칭하지 않는다")
-        void detectionBeforeSearchStart_skipsItem() {
-            SimilarItemProjection projection = mockProjection(100L, 0.9);
-            given(cctvDetectionRepository.findById(1L)).willReturn(Optional.of(cctvDetection));
-            given(matchConfig.getSimilarityThreshold()).willReturn(0.7f);
-            given(cctvDetectionMatchRepository.findLostItems(any(), any(), any(), anyFloat()))
-                    .willReturn(List.of(projection));
-            given(itemPostRepository.findAllByItemIdsWithItem(any())).willReturn(List.of(itemPost));
-            // searchStartTime을 검출 시각보다 미래로 설정 → 검출 시각이 기준 이전이 됨
-            given(cctvMatchCriteriaResolver.resolve(lostItem))
-                    .willReturn(new CctvMatchCriteria(List.of(10L), LocalDateTime.now().plusHours(1)));
 
             cctvMatchService.matchCctvToLostItems(1L);
 
@@ -194,9 +175,9 @@ class CctvMatchServiceTest {
             given(cctvDetectionMatchRepository.findLostItems(any(), any(), any(), anyFloat()))
                     .willReturn(List.of(projection));
             given(itemPostRepository.findAllByItemIdsWithItem(any())).willReturn(List.of(itemPost));
-            // criteria.roomIds()에 검출 room(10L)이 포함되지 않음
-            given(cctvMatchCriteriaResolver.resolve(lostItem))
-                    .willReturn(new CctvMatchCriteria(List.of(99L), LocalDateTime.now().minusHours(3)));
+            // resolveRoomIds()에 검출 room(10L)이 포함되지 않음
+            given(cctvMatchCriteriaResolver.resolveRoomIds(lostItem))
+                    .willReturn(List.of(99L));
 
             cctvMatchService.matchCctvToLostItems(1L);
 
@@ -232,8 +213,8 @@ class CctvMatchServiceTest {
             given(cctvDetectionMatchRepository.findLostItems(any(), any(), any(), anyFloat()))
                     .willReturn(List.of(projection));
             given(itemPostRepository.findAllByItemIdsWithItem(any())).willReturn(List.of(itemPost));
-            given(cctvMatchCriteriaResolver.resolve(lostItem))
-                    .willReturn(new CctvMatchCriteria(List.of(10L), LocalDateTime.now().minusHours(3)));
+            given(cctvMatchCriteriaResolver.resolveRoomIds(lostItem))
+                    .willReturn(List.of(10L));
             given(cctvDetectionMatchRepository.existsByCctvDetectionAndItem(cctvDetection, lostItem)).willReturn(false);
             given(cctvDetectionMatchRepository.save(any())).willReturn(savedMatch);
 
@@ -294,8 +275,8 @@ class CctvMatchServiceTest {
         void emptyRoomIds_returnsEarlyWithoutQuery() {
             given(itemRepository.findByIdOrThrow(100L)).willReturn(lostItem);
             given(itemPostRepository.findByItem(lostItem)).willReturn(lostItemPost);
-            given(cctvMatchCriteriaResolver.resolve(lostItem))
-                    .willReturn(new CctvMatchCriteria(List.of(), LocalDateTime.now().minusHours(3)));
+            given(cctvMatchCriteriaResolver.resolveRoomIds(lostItem))
+                    .willReturn(List.of());
 
             cctvMatchService.matchLostItemsToCctv(100L);
 
@@ -309,8 +290,8 @@ class CctvMatchServiceTest {
             given(itemRepository.findByIdOrThrow(100L)).willReturn(lostItem);
             given(itemPostRepository.findByItem(lostItem)).willReturn(lostItemPost);
             given(matchConfig.getSimilarityThreshold()).willReturn(0.7f);
-            given(cctvMatchCriteriaResolver.resolve(lostItem))
-                    .willReturn(new CctvMatchCriteria(List.of(10L), LocalDateTime.now().minusHours(3)));
+            given(cctvMatchCriteriaResolver.resolveRoomIds(lostItem))
+                    .willReturn(List.of(10L));
             given(cctvDetectionMatchRepository.findDetections(any(), any(), any(), any(), anyFloat()))
                     .willReturn(List.of());
 
@@ -327,8 +308,8 @@ class CctvMatchServiceTest {
             given(itemRepository.findByIdOrThrow(100L)).willReturn(lostItem);
             given(itemPostRepository.findByItem(lostItem)).willReturn(lostItemPost);
             given(matchConfig.getSimilarityThreshold()).willReturn(0.7f);
-            given(cctvMatchCriteriaResolver.resolve(lostItem))
-                    .willReturn(new CctvMatchCriteria(List.of(10L), LocalDateTime.now().minusHours(3)));
+            given(cctvMatchCriteriaResolver.resolveRoomIds(lostItem))
+                    .willReturn(List.of(10L));
             given(cctvDetectionMatchRepository.findDetections(any(), any(), any(), any(), anyFloat()))
                     .willReturn(List.of(projection));
             // detectionId=50L에 해당하는 CctvDetection 없음
@@ -346,8 +327,8 @@ class CctvMatchServiceTest {
             given(itemRepository.findByIdOrThrow(100L)).willReturn(lostItem);
             given(itemPostRepository.findByItem(lostItem)).willReturn(lostItemPost);
             given(matchConfig.getSimilarityThreshold()).willReturn(0.7f);
-            given(cctvMatchCriteriaResolver.resolve(lostItem))
-                    .willReturn(new CctvMatchCriteria(List.of(10L), LocalDateTime.now().minusHours(3)));
+            given(cctvMatchCriteriaResolver.resolveRoomIds(lostItem))
+                    .willReturn(List.of(10L));
             given(cctvDetectionMatchRepository.findDetections(any(), any(), any(), any(), anyFloat()))
                     .willReturn(List.of(projection));
             given(cctvDetectionRepository.findAllById(any())).willReturn(List.of(cctvDetection));
@@ -368,8 +349,8 @@ class CctvMatchServiceTest {
             given(itemPostRepository.findByItem(lostItem)).willReturn(lostItemPost);
             given(matchConfig.getSimilarityThreshold()).willReturn(0.7f);
             given(matchConfig.getColorBonus()).willReturn(1.1f);
-            given(cctvMatchCriteriaResolver.resolve(lostItem))
-                    .willReturn(new CctvMatchCriteria(List.of(10L), LocalDateTime.now().minusHours(3)));
+            given(cctvMatchCriteriaResolver.resolveRoomIds(lostItem))
+                    .willReturn(List.of(10L));
             given(cctvDetectionMatchRepository.findDetections(any(), any(), any(), any(), anyFloat()))
                     .willReturn(List.of(projection));
             given(cctvDetectionRepository.findAllById(any())).willReturn(List.of(cctvDetection));

--- a/src/test/java/com/zoopick/server/service/CreateCctvMatchEventListnerTest.java
+++ b/src/test/java/com/zoopick/server/service/CreateCctvMatchEventListnerTest.java
@@ -2,6 +2,7 @@ package com.zoopick.server.service;
 
 import com.zoopick.server.dto.match.CreateCctvMatchEvent;
 import com.zoopick.server.entity.*;
+import com.zoopick.server.repository.UserRepository;
 import com.zoopick.server.service.notification.NotificationService;
 import com.zoopick.server.service.notification.SendNotificationCommand;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -23,6 +25,7 @@ import static org.mockito.BDDMockito.*;
 class CreateCctvMatchEventListnerTest {
 
     @Mock NotificationService notificationService;
+    @Mock UserRepository userRepository;
 
     @InjectMocks CreateCctvMatchEventListner listener;
 
@@ -57,12 +60,21 @@ class CreateCctvMatchEventListnerTest {
         itemPost = ItemPost.builder().id(1L).item(item).title("지갑 잃어버렸어요").build();
         room = Room.builder().id(10L).name("101호").build();
 
-        event = new CreateCctvMatchEvent(item, match, cctvDetection, itemPost, room);
+        event = new CreateCctvMatchEvent(List.of(new CreateCctvMatchEvent.Entry(
+                match.getId(),
+                match.getScore(),
+                item.getId(),
+                reporter.getId(),
+                itemPost.getTitle(),
+                room.getName()
+        )));
     }
 
     @Test
     @DisplayName("매칭 이벤트 수신 시 신고자에게 FCM 알림을 전송한다")
     void handleMatchCreated_sendsNotificationToReporter() {
+        given(userRepository.findAllById(any())).willReturn(List.of(reporter));
+
         listener.handleMatchCreated(event);
 
         then(notificationService).should().send(eq(reporter), any(SendNotificationCommand.class));
@@ -71,6 +83,7 @@ class CreateCctvMatchEventListnerTest {
     @Test
     @DisplayName("알림 제목에 '도난 의심'이 포함된다")
     void handleMatchCreated_notificationTitleContainsTheftSuspected() {
+        given(userRepository.findAllById(any())).willReturn(List.of(reporter));
         ArgumentCaptor<SendNotificationCommand> captor = ArgumentCaptor.forClass(SendNotificationCommand.class);
 
         listener.handleMatchCreated(event);
@@ -82,6 +95,7 @@ class CreateCctvMatchEventListnerTest {
     @Test
     @DisplayName("알림 본문에 게시글 제목과 장소명이 포함된다")
     void handleMatchCreated_notificationBodyContainsTitleAndRoom() {
+        given(userRepository.findAllById(any())).willReturn(List.of(reporter));
         ArgumentCaptor<SendNotificationCommand> captor = ArgumentCaptor.forClass(SendNotificationCommand.class);
 
         listener.handleMatchCreated(event);


### PR DESCRIPTION
…RoomIds()를 호출하여 List<Long>을 반환하도록 Mock 설정을 업데이트
-  detectionBeforeSearchStart_skipsItem 테스트 케이스를 삭제
- CreateCctvMatchEvent가 단일 필드들 대신 List<Entry>를 받도록 변경된 구조를 반영

**1. CctvMatchServiceTest.java**
    - CctvMatchCriteria 제거: 리팩토링 과정에서 삭제된 CctvMatchCriteria 클래스에 대한 import 및 사용 코드를 제거했습니다.
    - Resolver 메서드 변경: cctvMatchCriteriaResolver.resolve() 대신 resolveRoomIds()를 호출하여 List<Long>을 반환하도록 Mock 설정을 업데이트했습니다.
    - 불필요한 테스트 제거: 서비스 로직 변경으로 더 이상 사용되지 않는 detectionBeforeSearchStart_skipsItem 테스트 케이스를 삭제했습니다.

**2. CreateCctvMatchEventListnerTest.java**
   - 이벤트 구조 업데이트: CreateCctvMatchEvent가 단일 필드들 대신 List<Entry>를 받도록 변경된 구조를 반영했습니다.
   - UserRepository Mock 추가: 리스너가 신고자 정보를 조회하기 위해 사용하는 UserRepository를 Mock으로 추가하고, 테스트 데이터(reporter)를 반환하도록 설정했습니다.

  검증 결과
  mvn test 명령어를 통해 두 테스트 클래스가 모두 정상적으로 통과됨을 확인했습니다.
