### PR TITLE
Fix: Item Post 시간 오류 수정

### DIFF
--- a/src/main/java/com/zoopick/server/dto/item/CreateItemPostRequest.java
+++ b/src/main/java/com/zoopick/server/dto/item/CreateItemPostRequest.java
@@ -9,7 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 @Getter
 @Setter
@@ -39,5 +39,5 @@ public class CreateItemPostRequest {
     private String detailAddress;
 
     @JsonProperty("reported_at")
-    private LocalDateTime reportedAt;
+    private OffsetDateTime reportedAt;
 }

--- a/src/main/java/com/zoopick/server/service/ItemPostService.java
+++ b/src/main/java/com/zoopick/server/service/ItemPostService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 @Service
@@ -44,7 +45,9 @@ public class ItemPostService {
                 .reportedBuilding(building)
                 .locationName(request.getDetailAddress())
                 .imageUrl(request.getImageUrl())
-                .reportedAt(request.getReportedAt() != null ? request.getReportedAt() : LocalDateTime.now())
+                .reportedAt(request.getReportedAt() != null
+                        ? request.getReportedAt().atZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime()
+                        : LocalDateTime.now())
                 .build();
 
         Item savedItem = itemRepository.save(item);


### PR DESCRIPTION
- https://github.com/2026-mju-capstone/backend/issues/114
## 테스트
<img width="341" height="127" alt="스크린샷 2026-05-20 09 15 47" src="https://github.com/user-attachments/assets/2400830e-d859-40b2-ad51-910d20c5aa52" />
<img width="341" height="59" alt="스크린샷 2026-05-20 09 16 50" src="https://github.com/user-attachments/assets/8135d99c-a80c-4684-8c26-9474b575d0ff" />
<img width="333" height="310" alt="스크린샷 2026-05-20 09 15 53" src="https://github.com/user-attachments/assets/e2d70e5a-e1a4-4961-9f17-aef5cab32d85" />

- [x] 분실물 등록 시 시간표상 강의실로 좁혀지는지 확인 (해당 시각/건물 수업 있을 때)