### PR TITLE
FastAPI 헬스체크 도입 및 Exception 처리 세분화

### DIFF
--- a/src/main/java/com/zoopick/server/config/FastApiProperties.java
+++ b/src/main/java/com/zoopick/server/config/FastApiProperties.java
@@ -29,6 +29,7 @@ public class FastApiProperties {
     public static class Cctv {
         private String enqueuePath;
         private String statusPath;
+        private String healthPath;
         private Duration connectTimeout;
         private Duration readTimeout;
     }

--- a/src/main/java/com/zoopick/server/controller/CctvController.java
+++ b/src/main/java/com/zoopick/server/controller/CctvController.java
@@ -40,7 +40,8 @@ public class CctvController {
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "202", description = "등록 + 큐 등록 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 (room_id 없음, video_url 형식 오류 등)"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 또는 FastAPI enqueue 실패 (room_id 없음, video_url 형식 오류 등)"),
+            @ApiResponse(responseCode = "503", description = "AI(FastAPI) 서버가 응답하지 않아 등록을 진행할 수 없음 (헬스체크 실패)"),
     })
     @PostMapping("/videos")
     public ResponseEntity<CommonResponse<CctvVideoCreateResponse>> createVideoAndEnqueue(@Valid @RequestBody CctvVideoCreateRequest request) {
@@ -58,6 +59,7 @@ public class CctvController {
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "202", description = "재큐잉 성공"),
+            @ApiResponse(responseCode = "400", description = "이미 진행 중/완료된 영상이거나 FastAPI 요청 실패"),
             @ApiResponse(responseCode = "404", description = "영상을 찾을 수 없음"),
     })
     @PostMapping("/enqueue/{videoId}")

--- a/src/main/java/com/zoopick/server/controller/CctvInternalController.java
+++ b/src/main/java/com/zoopick/server/controller/CctvInternalController.java
@@ -42,7 +42,7 @@ public class CctvInternalController {
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "진행률 업데이트 성공"),
-            @ApiResponse(responseCode = "404", description = "video_id를 찾을 수 없음"),
+            @ApiResponse(responseCode = "400", description = "video_id에 해당하는 progress를 찾을 수 없음"),
     })
     @PostMapping("/progress")
     public ResponseEntity<?> updateProgress(@RequestBody CctvProgressCallback callback) {
@@ -59,14 +59,14 @@ public class CctvInternalController {
             - detection_id: AI 서버가 발급한 멱등성 키 (중복 호출 방어)
             - embedding: 검출 장면의 CLIP 임베딩
             - 스냅샷 파일명 (item / moment 두 종류)
-            
+
             호출 주체: FastAPI 백그라운드 워커
-            멱등성 보장: 같은 detection_id 재호출 시 무시
+            멱등성 보장: 같은 detection_id 재호출 시 200 OK + duplicate=true 응답
             """
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "검출 등록 성공"),
-            @ApiResponse(responseCode = "409", description = "이미 처리된 detection_id (멱등성)"),
+            @ApiResponse(responseCode = "200", description = "검출 등록 성공 (또는 중복 호출 시 duplicate=true)"),
+            @ApiResponse(responseCode = "404", description = "video_id를 찾을 수 없음"),
     })
     @PostMapping("/detection")
     public ResponseEntity<?> registerDetection(@RequestBody CctvDetectionCallback callback) {

--- a/src/main/java/com/zoopick/server/controller/ZoopickExceptionHandler.java
+++ b/src/main/java/com/zoopick/server/controller/ZoopickExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.zoopick.server.controller;
 
 import com.zoopick.server.dto.CommonResponse;
+import com.zoopick.server.exception.FastApiUnavailableException;
 import com.zoopick.server.exception.ZoopickException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
@@ -55,6 +56,16 @@ public class ZoopickExceptionHandler {
     public ResponseEntity<CommonResponse<Void>> handleNoResourceFoundException(NoResourceFoundException exception) {
         log.warn(exception.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(CommonResponse.error("존재하지 않는 경로입니다."));
+    }
+
+    /**
+     * FastAPI 미응답은 운영 환경에서 자주 발생할 수 있는 일시적 외부 의존성 장애이므로,
+     * stack trace 없이 짧은 WARN 한 줄만 로그로 남긴다.
+     */
+    @ExceptionHandler(FastApiUnavailableException.class)
+    public <T> ResponseEntity<CommonResponse<T>> handleFastApiUnavailable(FastApiUnavailableException exception, HttpServletRequest request) {
+        log.warn("({}) {} - {}", request.getRemoteAddr(), exception.getClientMessage(), exception.getMessage());
+        return exception.createResponseEntity();
     }
 
     /**

--- a/src/main/java/com/zoopick/server/exception/FastApiUnavailableException.java
+++ b/src/main/java/com/zoopick/server/exception/FastApiUnavailableException.java
@@ -1,0 +1,16 @@
+package com.zoopick.server.exception;
+
+import org.jspecify.annotations.NullMarked;
+import org.springframework.http.HttpStatus;
+
+@NullMarked
+public class FastApiUnavailableException extends ZoopickException {
+
+    public FastApiUnavailableException(String clientMessage, String exceptionMessage) {
+        super(HttpStatus.SERVICE_UNAVAILABLE, clientMessage, exceptionMessage);
+    }
+
+    public FastApiUnavailableException(String clientMessage, String exceptionMessage, Throwable cause) {
+        super(HttpStatus.SERVICE_UNAVAILABLE, clientMessage, exceptionMessage, cause);
+    }
+}

--- a/src/main/java/com/zoopick/server/service/CctvService.java
+++ b/src/main/java/com/zoopick/server/service/CctvService.java
@@ -7,6 +7,7 @@ import com.zoopick.server.entity.*;
 import com.zoopick.server.exception.BadRequestException;
 import com.zoopick.server.exception.DataNotFoundException;
 import com.zoopick.server.exception.ForbiddenException;
+import com.zoopick.server.exception.FastApiUnavailableException;
 import com.zoopick.server.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -71,25 +72,36 @@ public class CctvService {
         return savedVideo.getId();
     }
 
+    @Transactional
     public CctvVideoCreateResponse createVideoAndEnqueue(CctvVideoCreateRequest request) {
-        Long videoId = createVideo(request);
+        // 1. FastAPI 헬스체크 (실패 시 ServiceUnavailableException → 503, DB/디스크 변경 없음)
+        cctvHealthCheck();
 
+        // 2. video 저장 + enqueue를 한 트랜잭션으로 묶어 처리
+        //    (enqueue 실패 시 video/progress 둘 다 rollback → orphan row 방지)
+        Long videoId = createVideo(request);
+        CctvEnqueueResponse enqueueResponse = enqueueVideo(videoId);
+
+        return CctvVideoCreateResponse.builder()
+                .videoId(videoId)
+                .queued(enqueueResponse != null && enqueueResponse.isQueued())
+                .queuePosition(enqueueResponse != null ? enqueueResponse.getQueuePosition() : null)
+                .estimatedStartAt(enqueueResponse != null ? enqueueResponse.getEstimatedStartAt() : null)
+                .build();
+    }
+
+    private void cctvHealthCheck() {
+        String url = fastApiProperties.getBaseUrl() + fastApiProperties.getCctv().getHealthPath();
         try {
-            CctvEnqueueResponse enqueueResponse = enqueueVideo(videoId);
-            return CctvVideoCreateResponse.builder()
-                    .videoId(videoId)
-                    .queued(enqueueResponse != null && enqueueResponse.isQueued())
-                    .queuePosition(enqueueResponse != null ? enqueueResponse.getQueuePosition() : null)
-                    .estimatedStartAt(enqueueResponse != null ? enqueueResponse.getEstimatedStartAt() : null)
-                    .build();
-        } catch (BadRequestException exception) {
-            log.warn("CCTV enqueue failed after video save: video_id={}, reason={}", videoId,
-                    exception.getClientMessage());
-            return CctvVideoCreateResponse.builder()
-                    .videoId(videoId)
-                    .queued(false)
-                    .reason(exception.getClientMessage())
-                    .build();
+            fastApiRestClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception e) {
+            throw new FastApiUnavailableException(
+                    "AI 서버가 응답하지 않습니다. 잠시 후 다시 시도해주세요.",
+                    "FastAPI healthcheck failed: " + e.getMessage(),
+                    e);
         }
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,6 +36,7 @@ fastapi.vision.connect-timeout=3s
 fastapi.vision.read-timeout=10s
 fastapi.cctv.enqueue-path=/cctv/enqueue
 fastapi.cctv.status-path=/cctv/status
+fastapi.cctv.health-path=/health
 fastapi.cctv.connect-timeout=3s
 fastapi.cctv.read-timeout=3s
 zoopick.callback-url=${ZOOPICK_CALLBACK_URL:http://localhost:8080}


### PR DESCRIPTION
## Summary
FastAPI가 꺼져 있어도 video가 db에 먼저 들어가버리는 문제를 해결했습니다. 
등록 진입 시점에 FastAPI `/health`를 호출해 사전 검증하고, 이후 전 과정을 단일 트랜잭션으로 묶어 enqueue 실패 시 video/progress 모두 rollback되도록 했습니다.

## 변경 내용

### Fix — orphan row 방지
- `FastApiUnavailableException(503)` 신규 예외 추가
- `fastapi.cctv.health-path` 설정 추가
- `CctvService.createVideoAndEnqueue`에 `@Transactional` 적용 + 진입 시점 헬스체크
- FastAPI 다운 시 503 반환 (DB/디스크 변경 없음)
- enqueue 단계 실패 시 video/progress 모두 rollback
- `ZoopickExceptionHandler`에 `FastApiUnavailableException` 전용 핸들러 추가 (stack trace 없이 WARN 한 줄만)

### Docs — Swagger 정합화
- `POST /api/cctv/videos`: 503 추가, 400 설명 보강
- `POST /api/cctv/enqueue/{videoId}`: 400 추가
- `POST /api/internal/cctv/progress`: 404 → 400 정정
- `POST /api/internal/cctv/detection`: 409 제거, 404 추가, 중복 호출 응답 명시