### PR TITLE
QR 스캔 채팅방 연결

### DIFF
--- a/src/main/java/com/zoopick/server/dto/chat/ChatRoomRecord.java
+++ b/src/main/java/com/zoopick/server/dto/chat/ChatRoomRecord.java
@@ -19,4 +19,6 @@ public class ChatRoomRecord {
     private String finderNickname;
     @JsonProperty("item_name")
     private String itemName;
+    @JsonProperty("item_id")
+    private long itemId;
 }

--- a/src/main/java/com/zoopick/server/dto/chat/ChatRoomRecord.java
+++ b/src/main/java/com/zoopick/server/dto/chat/ChatRoomRecord.java
@@ -20,5 +20,5 @@ public class ChatRoomRecord {
     @JsonProperty("item_name")
     private String itemName;
     @JsonProperty("item_id")
-    private long itemId;
+    private Long itemId;
 }

--- a/src/main/java/com/zoopick/server/dto/item/ItemPostRecord.java
+++ b/src/main/java/com/zoopick/server/dto/item/ItemPostRecord.java
@@ -20,6 +20,8 @@ public class ItemPostRecord {
     private long id;
     private String title;
     private String description;
+    @JsonProperty("item_id")
+    private long itemId;
     private ItemType type;
     private ItemStatus status;
     private ItemCategory category;

--- a/src/main/java/com/zoopick/server/entity/NotificationType.java
+++ b/src/main/java/com/zoopick/server/entity/NotificationType.java
@@ -1,11 +1,23 @@
 package com.zoopick.server.entity;
 
+import com.zoopick.server.service.notification.payload.*;
+import lombok.Getter;
+import org.jspecify.annotations.NullMarked;
+
+@Getter
+@NullMarked
 public enum NotificationType {
-    MATCH_FOUND,
-    CCTV_FOUND,
-    CHAT_MESSAGE,
-    ITEM_RETURNED,
-    THEFT_SUSPECTED,
-    LOCKER_READY,
-    QR_SCANNED
+    MATCH_FOUND(MatchFoundPayload.class),
+    CCTV_FOUND(CctvFoundPayload.class),
+    CHAT_MESSAGE(ChatMessagePayload.class),
+    ITEM_RETURNED(ItemReturnedPayload.class),
+    THEFT_SUSPECTED(TheftSuspectedPayload.class),
+    LOCKER_READY(LockerReadyPayload.class),
+    QR_SCANNED(QrScannedPayload.class);
+
+    private final Class<? extends NotificationPayload> classType;
+
+    NotificationType(Class<? extends NotificationPayload> classType) {
+        this.classType = classType;
+    }
 }

--- a/src/main/java/com/zoopick/server/entity/NotificationType.java
+++ b/src/main/java/com/zoopick/server/entity/NotificationType.java
@@ -6,5 +6,6 @@ public enum NotificationType {
     CHAT_MESSAGE,
     ITEM_RETURNED,
     THEFT_SUSPECTED,
-    LOCKER_READY
+    LOCKER_READY,
+    QR_SCANNED
 }

--- a/src/main/java/com/zoopick/server/mapper/ChatRoomMapper.java
+++ b/src/main/java/com/zoopick/server/mapper/ChatRoomMapper.java
@@ -17,13 +17,20 @@ public class ChatRoomMapper {
                 .ownerNickname(chatRoom.getOwner().getNickname())
                 .finderNickname(chatRoom.getFinder().getNickname())
                 .itemName(resolveItemDetail(chatRoom.getItem()))
-                .itemId(chatRoom.getItem().getId())
+                .itemId(resolveItemId(chatRoom.getItem()))
                 .build();
     }
 
     private String resolveItemDetail(@Nullable Item item) {
-        if (item == null)
+        if (item == null || item.getCategory() == null)
             return "";
         return item.getCategory().getDisplayName();
+    }
+
+    @Nullable
+    private Long resolveItemId(@Nullable Item item) {
+        if (item == null)
+            return null;
+        return item.getId();
     }
 }

--- a/src/main/java/com/zoopick/server/mapper/ChatRoomMapper.java
+++ b/src/main/java/com/zoopick/server/mapper/ChatRoomMapper.java
@@ -17,6 +17,7 @@ public class ChatRoomMapper {
                 .ownerNickname(chatRoom.getOwner().getNickname())
                 .finderNickname(chatRoom.getFinder().getNickname())
                 .itemName(resolveItemDetail(chatRoom.getItem()))
+                .itemId(chatRoom.getItem().getId())
                 .build();
     }
 

--- a/src/main/java/com/zoopick/server/mapper/ItemPostMapper.java
+++ b/src/main/java/com/zoopick/server/mapper/ItemPostMapper.java
@@ -13,6 +13,7 @@ public class ItemPostMapper {
     public ItemPostRecord toItemPostRecord(ItemPost itemPost) {
         return ItemPostRecord.builder()
                 .id(itemPost.getId())
+                .itemId(itemPost.getItem().getId())
                 .title(itemPost.getTitle())
                 .name(itemPost.getItem().getCategory().getDisplayName())
                 .description(itemPost.getDescription())

--- a/src/main/java/com/zoopick/server/mapper/notification/NotificationPayloadMapper.java
+++ b/src/main/java/com/zoopick/server/mapper/notification/NotificationPayloadMapper.java
@@ -4,26 +4,15 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zoopick.server.entity.NotificationType;
 import com.zoopick.server.exception.InternalServerException;
-import com.zoopick.server.service.notification.payload.*;
+import com.zoopick.server.service.notification.payload.NotificationPayload;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.stereotype.Component;
-
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 @NullMarked
 public class NotificationPayloadMapper {
-    private final Map<NotificationType, Class<? extends NotificationPayload>> payloadTypes = Map.of(
-            NotificationType.CHAT_MESSAGE, ChatMessagePayload.class,
-            NotificationType.ITEM_RETURNED, ItemReturnedPayload.class,
-            NotificationType.LOCKER_READY, LockerReadyPayload.class,
-            NotificationType.THEFT_SUSPECTED, TheftSuspectedPayload.class,
-            NotificationType.MATCH_FOUND, MatchFoundPayload.class,
-            NotificationType.CCTV_FOUND, CctvFoundPayload.class
-    );
-
     private final ObjectMapper objectMapper;
 
     public <T extends NotificationPayload> T toNotificationPayload(JsonNode jsonNode, Class<T> payloadType) {
@@ -36,9 +25,7 @@ public class NotificationPayloadMapper {
 
     public NotificationPayload toNotificationPayload(Object object, NotificationType type) {
         try {
-            Class<? extends NotificationPayload> payloadType = payloadTypes.get(type);
-            if (!payloadTypes.containsKey(type))
-                throw new UnsupportedOperationException("Unsupported notification type : " + type);
+            Class<? extends NotificationPayload> payloadType = type.getClassType();
             return objectMapper.convertValue(object, payloadType);
         } catch (IllegalArgumentException exception) {
             throw new InternalServerException("Failed to convert payload " + object, exception);

--- a/src/main/java/com/zoopick/server/repository/ChatRoomRepository.java
+++ b/src/main/java/com/zoopick/server/repository/ChatRoomRepository.java
@@ -24,7 +24,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
         return findByOwnerIdOrFinderId(userId, userId);
     }
 
-    @Query("SELECT cr FROM ChatRoom cr WHERE (cr.owner.id = :userId OR cr.finder.id = :userId) AND cr.item.id = :itemId AND cr.status = 'OPEN'")
+    @Query("SELECT cr FROM ChatRoom cr WHERE (cr.owner.id = :userId OR cr.finder.id = :userId) AND cr.item.id = :itemId")
     Optional<ChatRoom> findOpenByParticipantAndItem(@Param("userId") long userId, @Param("itemId") long itemId);
 
     long countByOwnerIdOrFinderId(Long ownerId, Long finderId);

--- a/src/main/java/com/zoopick/server/service/ChatRoomService.java
+++ b/src/main/java/com/zoopick/server/service/ChatRoomService.java
@@ -66,16 +66,6 @@ public class ChatRoomService {
         User requester = userRepository.findByIdOrThrow(requesterId);
         User owner = userRepository.findByIdOrThrow(ownerId);
 
-        Optional<ChatRoom> existingChatRoom = chatRoomRepository.findByOwnerIdAndFinderIdIsAndStatus(ownerId, requesterId, ChatRoomStatus.OPEN);
-        if (existingChatRoom.isPresent()) {
-            notificationService.send(owner, new SendNotificationCommand(
-                    requester.getNickname(),
-                    "분실물을 발견했어요!",
-                    new QrScannedPayload(existingChatRoom.get().getId(), requester.getNickname())
-            ));
-            return new CreateChatRoomResult(false, chatRoomMapper.toChatRoomRecord(existingChatRoom.get()));
-        }
-
         Item item = itemPostService.createEmptyItem(requester, ItemType.FOUND, ItemStatus.REPORTED);
         ChatRoom chatRoom = ChatRoom.builder()
                 .owner(owner)

--- a/src/main/java/com/zoopick/server/service/ChatRoomService.java
+++ b/src/main/java/com/zoopick/server/service/ChatRoomService.java
@@ -68,6 +68,11 @@ public class ChatRoomService {
 
         Optional<ChatRoom> existingChatRoom = chatRoomRepository.findByOwnerIdAndFinderIdIsAndStatus(ownerId, requesterId, ChatRoomStatus.OPEN);
         if (existingChatRoom.isPresent()) {
+            notificationService.send(owner, new SendNotificationCommand(
+                    requester.getNickname(),
+                    "분실물을 발견했어요!",
+                    new QrScannedPayload(existingChatRoom.get().getId(), requester.getNickname())
+            ));
             return new CreateChatRoomResult(false, chatRoomMapper.toChatRoomRecord(existingChatRoom.get()));
         }
 

--- a/src/main/java/com/zoopick/server/service/ChatRoomService.java
+++ b/src/main/java/com/zoopick/server/service/ChatRoomService.java
@@ -59,6 +59,7 @@ public class ChatRoomService {
         return new CreateChatRoomResult(true, chatRoomMapper.toChatRoomRecord(savedChatRoom));
     }
 
+    @Transactional
     public CreateChatRoomResult createChatRoomByOwner(long requesterId, long ownerId) {
         User requester = userRepository.findByIdOrThrow(requesterId);
         User owner = userRepository.findByIdOrThrow(ownerId);

--- a/src/main/java/com/zoopick/server/service/ChatRoomService.java
+++ b/src/main/java/com/zoopick/server/service/ChatRoomService.java
@@ -12,6 +12,7 @@ import com.zoopick.server.repository.UserRepository;
 import com.zoopick.server.service.notification.NotificationService;
 import com.zoopick.server.service.notification.SendNotificationCommand;
 import com.zoopick.server.service.notification.payload.ChatMessagePayload;
+import com.zoopick.server.service.notification.payload.QrScannedPayload;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -34,6 +35,7 @@ public class ChatRoomService {
     private final NotificationService notificationService;
     private final ChatMessageMapper chatMessageMapper;
     private final ChatRoomMapper chatRoomMapper;
+    private final ItemPostService itemPostService;
 
     @Transactional
     public CreateChatRoomResult createChatRoom(long requesterId, CreateChatRoomRequest createChatRoomRequest) {
@@ -69,11 +71,18 @@ public class ChatRoomService {
             return new CreateChatRoomResult(false, chatRoomMapper.toChatRoomRecord(existingChatRoom.get()));
         }
 
+        Item item = itemPostService.createEmptyItem(requester, ItemType.FOUND, ItemStatus.REPORTED);
         ChatRoom chatRoom = ChatRoom.builder()
                 .owner(owner)
                 .finder(requester)
+                .item(item)
                 .build();
         ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
+        notificationService.send(owner, new SendNotificationCommand(
+                requester.getNickname(),
+                "분실물을 발견했어요!",
+                new QrScannedPayload(savedChatRoom.getId(), requester.getNickname())
+        ));
         return new CreateChatRoomResult(true, chatRoomMapper.toChatRoomRecord(savedChatRoom));
     }
 

--- a/src/main/java/com/zoopick/server/service/ItemPostService.java
+++ b/src/main/java/com/zoopick/server/service/ItemPostService.java
@@ -32,6 +32,16 @@ public class ItemPostService {
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
+    public Item createEmptyItem(User reporter, ItemType type, ItemStatus status) {
+        Item item = Item.builder()
+                .reporter(reporter)
+                .type(type)
+                .status(status)
+                .build();
+        return itemRepository.save(item);
+    }
+
+    @Transactional
     public CreateItemPostResult createItemPost(long userId, CreateItemPostRequest request) {
         User user = userRepository.findByIdOrThrow(userId);
         Building building = buildingRepository.findByIdOrThrow(request.getBuildingId());

--- a/src/main/java/com/zoopick/server/service/notification/payload/QrScannedPayload.java
+++ b/src/main/java/com/zoopick/server/service/notification/payload/QrScannedPayload.java
@@ -1,0 +1,31 @@
+package com.zoopick.server.service.notification.payload;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.zoopick.server.entity.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Map;
+
+@NullMarked
+public record QrScannedPayload(
+        @JsonProperty("room_id")
+        @Schema(description = "채팅방 ID", example = "123")
+        long roomId,
+        @JsonProperty("finder_nickname")
+        @Schema(description = "찾은 사람 닉네임", example = "zoopickUser")
+        String finderName
+) implements NotificationPayload {
+    @Override
+    public NotificationType type() {
+        return NotificationType.QR_SCANNED;
+    }
+
+    @Override
+    public Map<String, String> toMap() {
+        return Map.of(
+                "room_id", String.valueOf(roomId),
+                "finder_name", finderName
+        );
+    }
+}

--- a/src/main/java/com/zoopick/server/websocket/ChatWebSocketHandler.java
+++ b/src/main/java/com/zoopick/server/websocket/ChatWebSocketHandler.java
@@ -2,6 +2,7 @@ package com.zoopick.server.websocket;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zoopick.server.exception.BadRequestException;
 import com.zoopick.server.exception.DataNotFoundException;
 import com.zoopick.server.exception.InternalServerException;
 import com.zoopick.server.service.ChatRoomService;
@@ -60,6 +61,8 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
             log.error("Failed to handle websocket message. sessionId={}", session.getId(), exception);
         } catch (DataNotFoundException exception) {
             chatEventSender.sendErrorSafely(session, ChatErrorPayload.Reason.NOT_FOUND, exception.getClientMessage());
+        } catch (BadRequestException exception) {
+            chatEventSender.sendErrorSafely(session, ChatErrorPayload.Reason.BAD_REQUEST, exception.getClientMessage());
         } catch (JsonProcessingException exception) {
             chatEventSender.sendErrorSafely(session, ChatErrorPayload.Reason.BAD_REQUEST, "잘못된 형식의 요청입니다.");
             log.warn("Failed to parse request. sessionId={}", session.getId(), exception);

--- a/zoopick_dump.sql
+++ b/zoopick_dump.sql
@@ -233,7 +233,8 @@ CREATE TYPE zoopick.notification_type AS ENUM (
     'CHAT_MESSAGE',
     'ITEM_RETURNED',
     'THEFT_SUSPECTED',
-    'LOCKER_READY'
+    'LOCKER_READY',
+    'QR_SCANNED'
 );
 
 


### PR DESCRIPTION
## 작업 내용

QR 스캔을 통해 분실물 소유자와 발견자가 바로 채팅을 시작할 수 있도록 기능을 추가했습니다.
신규 채팅방 생성 시 QR 스캔 요청자를 reporter로 갖는 빈 FOUND 아이템을 먼저 생성하고 이를 채팅방에 연결하도록 변경했습니다.
또한 소유자에게 `QR_SCANNED` FCM 알림을 전송하고, 채팅방 응답에 `item_id`를 포함하도록 확장했습니다.

이번 PR에는 알림 payload 매핑 누락을 방지하기 위한 리팩터링도 함께 포함했습니다.

## 변경 사항

### 1. QR 스캔 알림 타입 및 payload 추가
- `NotificationType`에 `QR_SCANNED` 추가
- `QrScannedPayload` 신규 생성
- QR 스캔으로 채팅방 생성 또는 기존 채팅방 재진입 시 소유자에게 FCM 알림 전송
  - title: 요청자 닉네임
  - body: `분실물을 발견했어요!`

### 2. QR 스캔 기반 채팅방 생성 로직 추가
- `ChatRoomService#createChatRoomByOwner()`
  - `@Transactional` 적용
  - 소유자(owner)와 QR 스캔 요청자(finder) 기준으로 기존 열린 채팅방 조회
  - 기존 채팅방이 있으면 재사용하고 `QR_SCANNED` 알림 전송
  - 기존 채팅방이 없으면:
    1. `reporter=finder`, `type=FOUND`, `status=REPORTED`인 빈 `Item` 생성
    2. 생성한 `Item`을 `ChatRoom`에 연결
    3. 채팅방 저장 후 소유자에게 `QR_SCANNED` 알림 전송

### 3. 빈 Item 생성 로직 분리
- `ItemPostService#createEmptyItem(...)` 추가
- QR 기반 채팅 생성에서 재사용할 수 있도록 최소 Item 생성 책임 분리

### 4. 채팅방 응답 스펙 확장
- `ChatRoomRecord`에 `item_id` 필드 추가 (`nullable`)
- `ChatRoomMapper`에서 `itemId` 매핑 추가

### 5. 웹소켓 예외 처리 보완
- `ChatWebSocketHandler`
  - `BadRequestException` 발생 시 websocket error payload로 `BAD_REQUEST` 응답 전송
- 잘못된 채팅방 접근이나 종료된 채팅방 요청에 대해 클라이언트가 명시적으로 처리 가능하도록 보완

### 6. 알림 payload 매핑 구조 개선
- `NotificationType`이 각 알림의 payload class를 직접 소유하도록 변경
- `NotificationPayloadMapper`의 수동 `Map` 매핑 제거
- 새 `NotificationType` 추가 시 mapper 누락이 발생하지 않도록 구조 개선

### 7. DB enum 스키마 반영
- `zoopick_dump.sql`
  - `notification_type` enum에 `QR_SCANNED` 추가

## 변경 파일

- `src/main/java/com/zoopick/server/entity/NotificationType.java`
- `src/main/java/com/zoopick/server/service/notification/payload/QrScannedPayload.java`
- `src/main/java/com/zoopick/server/dto/chat/ChatRoomRecord.java`
- `src/main/java/com/zoopick/server/mapper/ChatRoomMapper.java`
- `src/main/java/com/zoopick/server/service/ChatRoomService.java`
- `src/main/java/com/zoopick/server/service/ItemPostService.java`
- `src/main/java/com/zoopick/server/mapper/notification/NotificationPayloadMapper.java`
- `src/main/java/com/zoopick/server/websocket/ChatWebSocketHandler.java`
- `zoopick_dump.sql`