### PR TITLE
시간표 기반 푸쉬 알림

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <version>1.4.1</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springdoc</groupId>

--- a/src/main/java/com/zoopick/server/annotation/ServiceOnly.java
+++ b/src/main/java/com/zoopick/server/annotation/ServiceOnly.java
@@ -1,0 +1,10 @@
+package com.zoopick.server.annotation;
+
+import java.lang.annotation.*;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ServiceOnly {
+    Class<?>[] value();
+}

--- a/src/main/java/com/zoopick/server/auth/repository/UserRepository.java
+++ b/src/main/java/com/zoopick/server/auth/repository/UserRepository.java
@@ -2,8 +2,14 @@ package com.zoopick.server.auth.repository;
 
 import com.zoopick.server.auth.entity.User;
 import com.zoopick.server.exception.DataNotFoundException;
+import com.zoopick.server.metadata.entity.Building;
+import com.zoopick.server.timetable.entity.DayOfWeek;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -27,5 +33,24 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByNickname(String nickname);
 
+    @Query("""
+            select distinct tg.user
+            from TimetableGroup tg
+            join Timetable t on t.timetableGroup = tg
+            join CourseSchedule cs on cs.course = t.course
+            join t.course.room r
+            where tg.isPrimary = true
+              and tg.user <> :excludedUser
+              and r.building = :building
+              and cs.dayOfWeek = :dayOfWeek
+              and cs.startTime < :time
+              and cs.endTime > :time
+            """)
+    List<User> findUsersWithPrimaryTimetableAt(
+            @Param("building") Building building,
+            @Param("dayOfWeek") DayOfWeek dayOfWeek,
+            @Param("time") LocalTime time,
+            @Param("excludedUser") User excludedUser
+    );
 
 }

--- a/src/main/java/com/zoopick/server/cctv/CctvMatchCriteriaResolver.java
+++ b/src/main/java/com/zoopick/server/cctv/CctvMatchCriteriaResolver.java
@@ -67,7 +67,7 @@ public class CctvMatchCriteriaResolver {
             return Set.of();
         }
 
-        DayOfWeek targetDay = DayOfWeek.valueOf(reportedTime.getDayOfWeek().name().substring(0, 3));
+        DayOfWeek targetDay = DayOfWeek.from(reportedTime.getDayOfWeek());
         LocalTime targetLocalTime = reportedTime.toLocalTime();
 
         return courseScheduleRepository.findAllByCourseIn(buildingCourses).stream()

--- a/src/main/java/com/zoopick/server/cctv/service/CctvService.java
+++ b/src/main/java/com/zoopick/server/cctv/service/CctvService.java
@@ -14,6 +14,7 @@ import com.zoopick.server.exception.FastApiUnavailableException;
 import com.zoopick.server.exception.ForbiddenException;
 import com.zoopick.server.item.entity.Item;
 import com.zoopick.server.item.entity.ItemStatus;
+import com.zoopick.server.item.service.ItemService;
 import com.zoopick.server.metadata.entity.Room;
 import com.zoopick.server.metadata.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
@@ -54,6 +55,7 @@ public class CctvService {
     private final FastApiProperties fastApiProperties;
     private final ApplicationEventPublisher eventPublisher;
     private final CctvDetectionMatchRepository cctvDetectionMatchRepository;
+    private final ItemService itemService;
     @Value("${zoopick.callback-url}")
     private String callbackBaseUrl;
 
@@ -388,7 +390,7 @@ public class CctvService {
             LocalDateTime now = LocalDateTime.now();
             Item lostItem = cctvDetectionMatch.getItem();
             lostItem.theftSuspected(now);
-            lostItem.changeStatus(ItemStatus.THEFT_CONFIRMED);
+            itemService.changeItemStatus(lostItem.getId(), ItemStatus.THEFT_CONFIRMED);
             cctvDetectionMatchRepository.rejectOtherPendingMatches( // 나머지 reject 처리
                     lostItem.getId(),
                     matchId,

--- a/src/main/java/com/zoopick/server/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/zoopick/server/chat/repository/ChatRoomRepository.java
@@ -41,4 +41,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     Optional<ChatRoom> findByParticipantAndItem(@Param("userId") long userId, @Param("itemId") long itemId);
 
     List<ChatRoom> findAllByItem(Item item);
+
+    List<ChatRoom> findAllByItemAndStatus(Item item, ChatRoomStatus status);
 }

--- a/src/main/java/com/zoopick/server/chat/service/ChatRoomResolutionService.java
+++ b/src/main/java/com/zoopick/server/chat/service/ChatRoomResolutionService.java
@@ -1,0 +1,22 @@
+package com.zoopick.server.chat.service;
+
+import com.zoopick.server.chat.entity.ChatRoomStatus;
+import com.zoopick.server.chat.repository.ChatRoomRepository;
+import com.zoopick.server.item.entity.Item;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@NullMarked
+public class ChatRoomResolutionService {
+    private final ChatRoomRepository chatRoomRepository;
+
+    @Transactional
+    public void resolveReturnedItemRooms(Item item) {
+        chatRoomRepository.findAllByItemAndStatus(item, ChatRoomStatus.OPEN)
+                .forEach(chatRoom -> chatRoom.setStatus(ChatRoomStatus.RESOLVED_RETURNED));
+    }
+}

--- a/src/main/java/com/zoopick/server/item/entity/Item.java
+++ b/src/main/java/com/zoopick/server/item/entity/Item.java
@@ -1,6 +1,8 @@
 package com.zoopick.server.item.entity;
 
+import com.zoopick.server.annotation.ServiceOnly;
 import com.zoopick.server.auth.entity.User;
+import com.zoopick.server.item.service.ItemService;
 import com.zoopick.server.metadata.entity.Building;
 import jakarta.persistence.*;
 import lombok.*;
@@ -85,9 +87,13 @@ public class Item {
     private LocalDateTime updatedAt;
 
     /**
+     * 아이템 상태만 변경한다.
+     * 채팅방 종료, 이벤트 발행 등 부수 효과가 필요한 상태 변경은
+     * 이 메소드를 직접 호출하지 말고 {@link ItemService#changeItemStatus(long, ItemStatus)}를 사용한다.
+     *
      * @param status 바꿀 상태
-     * @see com.zoopick.server.item.service.ItemService#markItemAsReturned(long)
      */
+    @ServiceOnly(ItemService.class)
     public void changeStatus(ItemStatus status) {
         this.status = status;
         if (status == ItemStatus.RETURNED)

--- a/src/main/java/com/zoopick/server/item/event/ItemReturnedEventListener.java
+++ b/src/main/java/com/zoopick/server/item/event/ItemReturnedEventListener.java
@@ -2,7 +2,6 @@ package com.zoopick.server.item.event;
 
 import com.zoopick.server.auth.entity.User;
 import com.zoopick.server.chat.entity.ChatRoom;
-import com.zoopick.server.chat.entity.ChatRoomStatus;
 import com.zoopick.server.chat.repository.ChatRoomRepository;
 import com.zoopick.server.exception.InternalServerException;
 import com.zoopick.server.item.entity.Item;
@@ -28,6 +27,11 @@ public class ItemReturnedEventListener {
     private final ItemRepository itemRepository;
     private final NotificationService notificationService;
 
+    /**
+     * 도에인: 같은 item에 연결된 모든 chatRoom의 owner는 동일하다
+     *
+     * @param event 이벤트
+     */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleItemReturned(ItemReturnedEvent event) {
@@ -41,8 +45,6 @@ public class ItemReturnedEventListener {
         List<User> finders = chatRooms.stream()
                 .map(ChatRoom::getFinder)
                 .toList();
-
-        chatRooms.forEach(chatRoom -> chatRoom.setStatus(ChatRoomStatus.RESOLVED_RETURNED));
 
         notificationService.send(finders, new SendNotificationCommand(
                 owner.getNickname(),

--- a/src/main/java/com/zoopick/server/item/service/ItemService.java
+++ b/src/main/java/com/zoopick/server/item/service/ItemService.java
@@ -1,6 +1,7 @@
 package com.zoopick.server.item.service;
 
 import com.zoopick.server.auth.entity.User;
+import com.zoopick.server.chat.service.ChatRoomResolutionService;
 import com.zoopick.server.item.CreateItemCommand;
 import com.zoopick.server.item.entity.Item;
 import com.zoopick.server.item.entity.ItemStatus;
@@ -23,6 +24,7 @@ import java.time.ZoneId;
 public class ItemService {
     private final ItemRepository itemRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final ChatRoomResolutionService chatRoomResolutionService;
 
     @Transactional
     public Item createEmptyItem(User reporter, ItemType type, ItemStatus status) {
@@ -57,10 +59,15 @@ public class ItemService {
     }
 
     @Transactional
-    public void markItemAsReturned(long itemId) {
+    public void changeItemStatus(long itemId, ItemStatus itemStatus) {
         Item item = itemRepository.findByIdOrThrow(itemId);
-        item.changeStatus(ItemStatus.RETURNED);
+        if (itemStatus == ItemStatus.RETURNED) {
+            item.changeStatus(ItemStatus.RETURNED);
+            chatRoomResolutionService.resolveReturnedItemRooms(item);
 
-        applicationEventPublisher.publishEvent(new ItemReturnedEvent(itemId));
+            applicationEventPublisher.publishEvent(new ItemReturnedEvent(itemId));
+        } else {
+            item.changeStatus(itemStatus);
+        }
     }
 }

--- a/src/main/java/com/zoopick/server/itemmatch/service/ItemMatchService.java
+++ b/src/main/java/com/zoopick/server/itemmatch/service/ItemMatchService.java
@@ -6,6 +6,7 @@ import com.zoopick.server.item.entity.Item;
 import com.zoopick.server.item.entity.ItemStatus;
 import com.zoopick.server.item.entity.ItemType;
 import com.zoopick.server.item.repository.ItemRepository;
+import com.zoopick.server.item.service.ItemService;
 import com.zoopick.server.itemmatch.dto.*;
 import com.zoopick.server.itemmatch.entity.ItemMatch;
 import com.zoopick.server.itemmatch.entity.MatchManualType;
@@ -35,6 +36,7 @@ public class ItemMatchService {
     private final LockerRepository lockerRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final MatchConfig matchConfig;
+    private final ItemService itemService;
 
     @Transactional
     public void createMatch(Long itemId) {
@@ -128,8 +130,8 @@ public class ItemMatchService {
 
         boolean wasInLocker = foundItem.getStatus() == ItemStatus.IN_LOCKER;
 
-        lostItem.changeStatus(ItemStatus.MATCHED);
-        foundItem.changeStatus(ItemStatus.MATCHED);
+        itemService.changeItemStatus(lostItem.getId(), ItemStatus.MATCHED);
+        itemService.changeItemStatus(foundItem.getId(), ItemStatus.MATCHED);
         itemMatch.setStatus(MatchStatus.CONFIRMED);
 
         itemMatchRepository.rejectOthersByLostItem(matchId, lostItem.getId(), foundItem.getId());
@@ -190,8 +192,8 @@ public class ItemMatchService {
                 .build());
 
         // 수동 매칭 확정
-        lostItem.changeStatus(ItemStatus.MATCHED);
-        foundItem.changeStatus(ItemStatus.MATCHED);
+        itemService.changeItemStatus(lostItem.getId(), ItemStatus.MATCHED);
+        itemService.changeItemStatus(foundItem.getId(), ItemStatus.MATCHED);
 
         itemMatchRepository.rejectOthersByLostItem(savedMatch.getId(), lostItem.getId(), foundItem.getId());
         log.info("매칭 저장 완료 ID: {}", savedMatch.getId());

--- a/src/main/java/com/zoopick/server/itempost/event/ItemPostCreatedEvent.java
+++ b/src/main/java/com/zoopick/server/itempost/event/ItemPostCreatedEvent.java
@@ -1,0 +1,4 @@
+package com.zoopick.server.itempost.event;
+
+public record ItemPostCreatedEvent(Long itemPostId) {
+}

--- a/src/main/java/com/zoopick/server/itempost/event/ItemPostCreatedEventListener.java
+++ b/src/main/java/com/zoopick/server/itempost/event/ItemPostCreatedEventListener.java
@@ -1,0 +1,62 @@
+package com.zoopick.server.itempost.event;
+
+import com.zoopick.server.auth.entity.User;
+import com.zoopick.server.auth.repository.UserRepository;
+import com.zoopick.server.item.entity.Item;
+import com.zoopick.server.item.entity.ItemType;
+import com.zoopick.server.itempost.entity.ItemPost;
+import com.zoopick.server.itempost.repository.ItemPostRepository;
+import com.zoopick.server.metadata.entity.Building;
+import com.zoopick.server.notification.SendNotificationCommand;
+import com.zoopick.server.notification.payload.ItemReportedPayload;
+import com.zoopick.server.notification.service.NotificationService;
+import com.zoopick.server.timetable.entity.DayOfWeek;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@NullMarked
+public class ItemPostCreatedEventListener {
+    private final UserRepository userRepository;
+    private final NotificationService notificationService;
+    private final ItemPostRepository itemPostRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void sendNotificationToTimetableMatchingUsers(ItemPostCreatedEvent event) {
+        ItemPost itemPost = itemPostRepository.findByIdOrThrow(event.itemPostId());
+        User reporter = itemPost.getUser();
+        Item item = itemPost.getItem();
+        Building building = item.getReportedBuilding();
+        LocalDateTime reportedAt = item.getReportedAt();
+        List<User> users = userRepository.findUsersWithPrimaryTimetableAt(
+                building,
+                DayOfWeek.from(reportedAt.getDayOfWeek()),
+                reportedAt.toLocalTime(),
+                reporter
+        );
+
+        notificationService.send(users, new SendNotificationCommand(
+                reporter.getNickname(),
+                getNotificationBodyByItemType(item.getType()),
+                new ItemReportedPayload(
+                        item.getId(), item.getDisplayName(), itemPost.getId()
+                )
+        ));
+    }
+
+    private String getNotificationBodyByItemType(ItemType itemType) {
+        if (itemType == ItemType.LOST)
+            return "분실물이 있어요!";
+        return "분실물이 발견되었어요!";
+    }
+}

--- a/src/main/java/com/zoopick/server/itempost/service/ItemPostService.java
+++ b/src/main/java/com/zoopick/server/itempost/service/ItemPostService.java
@@ -14,6 +14,7 @@ import com.zoopick.server.itemmatch.entity.MatchStatus;
 import com.zoopick.server.itemmatch.repository.ItemMatchRepository;
 import com.zoopick.server.itempost.dto.*;
 import com.zoopick.server.itempost.entity.ItemPost;
+import com.zoopick.server.itempost.event.ItemPostCreatedEvent;
 import com.zoopick.server.itempost.mapper.ItemPostMapper;
 import com.zoopick.server.itempost.repository.ItemPostRepository;
 import com.zoopick.server.metadata.entity.Building;
@@ -21,6 +22,7 @@ import com.zoopick.server.metadata.repository.BuildingRepository;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -40,6 +42,7 @@ public class ItemPostService {
     private final ItemPostMapper itemPostMapper;
     private final ItemService itemService;
     private final CreateItemCommandMapper createItemCommandMapper;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
     public CreateItemPostResult createItemPost(long userId, CreateItemPostRequest request) {
@@ -55,6 +58,7 @@ public class ItemPostService {
                 .item(savedItem)
                 .build();
         ItemPost savedItemPost = itemPostRepository.save(itemPost);
+        applicationEventPublisher.publishEvent(new ItemPostCreatedEvent(savedItemPost.getId()));
         return new CreateItemPostResult(savedItemPost.getId(), savedItem.getId(), savedItem.getStatus(), "등록되었습니다.");
     }
 

--- a/src/main/java/com/zoopick/server/locker/service/LockerService.java
+++ b/src/main/java/com/zoopick/server/locker/service/LockerService.java
@@ -92,7 +92,7 @@ public class LockerService {
 
         locker.setStatus(LockerStatus.IN_USE);
         locker.setCurrentItem(item);
-        item.changeStatus(ItemStatus.IN_LOCKER);
+        itemService.changeItemStatus(item.getId(), ItemStatus.IN_LOCKER);
 
         log.info("[STORE] locker_id={} item_id={} user_id={} 보관 요청",
                 locker.getId(), itemId, userId);

--- a/src/main/java/com/zoopick/server/locker/service/LockerService.java
+++ b/src/main/java/com/zoopick/server/locker/service/LockerService.java
@@ -114,7 +114,7 @@ public class LockerService {
 
         locker.setStatus(LockerStatus.EMPTY);
         locker.setCurrentItem(null);
-        itemService.markItemAsReturned(stored.getId());
+        itemService.changeItemStatus(stored.getId(), ItemStatus.RETURNED);
 
         log.info("[RETRIEVE] locker_id={} item_id={} user_id={} 회수 요청",
                 locker.getId(), stored.getId(), userId);

--- a/src/main/java/com/zoopick/server/notification/entity/NotificationType.java
+++ b/src/main/java/com/zoopick/server/notification/entity/NotificationType.java
@@ -11,6 +11,7 @@ public enum NotificationType {
     CCTV_FOUND(CctvFoundPayload.class),
     CHAT_MESSAGE(ChatMessagePayload.class),
     ITEM_RETURNED(ItemReturnedPayload.class),
+    ITEM_REPORTED(ItemReportedPayload.class),
     THEFT_SUSPECTED(TheftSuspectedPayload.class),
     LOCKER_READY(LockerReadyPayload.class),
     QR_SCANNED(QrScannedPayload.class);

--- a/src/main/java/com/zoopick/server/notification/event/NotificationDispatchEventListener.java
+++ b/src/main/java/com/zoopick/server/notification/event/NotificationDispatchEventListener.java
@@ -1,5 +1,6 @@
 package com.zoopick.server.notification.event;
 
+import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
@@ -17,18 +18,24 @@ import java.util.List;
 @NullMarked
 public class NotificationDispatchEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(NotificationDispatchRequestedEvent event) throws FirebaseMessagingException {
+    public void handle(NotificationDispatchRequestedEvent event) {
         List<FcmMessageRequest> messageRequests = event.messages();
         List<Message> messages = messageRequests.stream()
                 .filter(FcmMessageRequest::hasToken)
                 .map(this::toMessage)
                 .toList();
 
-        if (!messages.isEmpty())
-            FirebaseMessaging.getInstance().sendEach(messages);
         int unspentCount = messageRequests.size() - messages.size();
         if (unspentCount > 0)
             log.warn("{} / {} notifications could not be dispatched", unspentCount, messageRequests.size());
+        try {
+            if (!messages.isEmpty()) {
+                BatchResponse response = FirebaseMessaging.getInstance().sendEach(messages);
+                log.warn("{} notifications failed to send", response.getFailureCount());
+            }
+        } catch (FirebaseMessagingException exception) {
+            log.error(exception.getMessage(), exception);
+        }
     }
 
     private Message toMessage(FcmMessageRequest request) {

--- a/src/main/java/com/zoopick/server/notification/payload/ItemReportedPayload.java
+++ b/src/main/java/com/zoopick/server/notification/payload/ItemReportedPayload.java
@@ -1,0 +1,41 @@
+package com.zoopick.server.notification.payload;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.zoopick.server.notification.entity.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Map;
+
+@NullMarked
+@Schema(
+        name = "ItemReportedPayload",
+        description = "ITEM_REPORTED : 게시글 등록 알림 payload"
+)
+public record ItemReportedPayload(
+        @JsonProperty("item_id")
+        @Schema(description = "물품 ID", example = "10")
+        long itemId,
+
+        @JsonProperty("item_name")
+        @Schema(description = "물품 이름", example = "인형")
+        String itemName,
+
+        @JsonProperty("item_post_id")
+        @Schema(description = "게시글 ID", example = "10")
+        long itemPostId
+) implements NotificationPayload {
+    @Override
+    public NotificationType type() {
+        return NotificationType.ITEM_REPORTED;
+    }
+
+    @Override
+    public Map<String, String> toMap() {
+        return Map.of(
+                "item_id", String.valueOf(itemId),
+                "item_name", itemName,
+                "item_post_id", String.valueOf(itemPostId)
+        );
+    }
+}

--- a/src/main/java/com/zoopick/server/notification/payload/QrScannedPayload.java
+++ b/src/main/java/com/zoopick/server/notification/payload/QrScannedPayload.java
@@ -7,6 +7,10 @@ import org.jspecify.annotations.NullMarked;
 
 import java.util.Map;
 
+@Schema(
+        name = "QrScannedPayload",
+        description = "QR_SCANNED : 사용자 QR payload"
+)
 @NullMarked
 public record QrScannedPayload(
         @JsonProperty("room_id")

--- a/src/main/java/com/zoopick/server/timetable/entity/DayOfWeek.java
+++ b/src/main/java/com/zoopick/server/timetable/entity/DayOfWeek.java
@@ -1,5 +1,21 @@
 package com.zoopick.server.timetable.entity;
 
 public enum DayOfWeek {
-    MON, TUE, WED, THU, FRI, SAT, SUN
+    MON, TUE, WED, THU, FRI, SAT, SUN;
+
+    public boolean matches(java.time.DayOfWeek dayOfWeek) {
+        return this == from(dayOfWeek);
+    }
+
+    public static DayOfWeek from(java.time.DayOfWeek dayOfWeek) {
+        return switch (dayOfWeek) {
+            case MONDAY -> MON;
+            case TUESDAY -> TUE;
+            case WEDNESDAY -> WED;
+            case THURSDAY -> THU;
+            case FRIDAY -> FRI;
+            case SATURDAY -> SAT;
+            case SUNDAY -> SUN;
+        };
+    }
 }

--- a/src/test/java/com/zoopick/server/architecture/ServiceOnlyArchitectureTest.java
+++ b/src/test/java/com/zoopick/server/architecture/ServiceOnlyArchitectureTest.java
@@ -1,0 +1,46 @@
+package com.zoopick.server.architecture;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.ArchRule;
+import com.zoopick.server.annotation.ServiceOnly;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+class ServiceOnlyArchitectureTest {
+    private final JavaClasses importedClasses = new ClassFileImporter().importPackages("com.zoopick.server");
+
+    @Test
+    void serviceOnlyMethodsShouldOnlyBeCalledByAllowedServices() {
+        importedClasses.stream()
+                .map(JavaClass::reflect)
+                .flatMap(javaClass -> Arrays.stream(javaClass.getDeclaredMethods()))
+                .filter(method -> method.isAnnotationPresent(ServiceOnly.class))
+                .forEach(this::assertAllowedCallersOnly);
+    }
+
+    private void assertAllowedCallersOnly(Method method) {
+        ServiceOnly serviceOnly = method.getAnnotation(ServiceOnly.class);
+        List<String> allowedCallerNames = Arrays.stream(serviceOnly.value())
+                .map(Class::getName)
+                .toList();
+
+        ArchRule rule = noClasses()
+                .that(new DescribedPredicate<>("are not allowed callers") {
+                    @Override
+                    public boolean test(JavaClass input) {
+                        return !allowedCallerNames.contains(input.getName());
+                    }
+                })
+                .should().callMethod(method.getDeclaringClass(), method.getName(), method.getParameterTypes());
+
+        rule.check(importedClasses);
+    }
+}

--- a/src/test/java/com/zoopick/server/architecture/ServiceOnlyArchitectureTest.java
+++ b/src/test/java/com/zoopick/server/architecture/ServiceOnlyArchitectureTest.java
@@ -4,6 +4,7 @@ import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.ArchRule;
 import com.zoopick.server.annotation.ServiceOnly;
 import org.junit.jupiter.api.Test;
@@ -15,7 +16,10 @@ import java.util.List;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 class ServiceOnlyArchitectureTest {
-    private final JavaClasses importedClasses = new ClassFileImporter().importPackages("com.zoopick.server");
+    private final JavaClasses importedClasses = new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_JARS)
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages("com.zoopick.server");
 
     @Test
     void serviceOnlyMethodsShouldOnlyBeCalledByAllowedServices() {

--- a/zoopick_dump.sql
+++ b/zoopick_dump.sql
@@ -232,6 +232,7 @@ CREATE TYPE zoopick.notification_type AS ENUM (
     'CCTV_FOUND',
     'CHAT_MESSAGE',
     'ITEM_RETURNED',
+    'ITEM_REPORTED',
     'THEFT_SUSPECTED',
     'LOCKER_READY',
     'QR_SCANNED'


### PR DESCRIPTION
## 주요 변경 사항

### 1. 게시글 생성 알림 추가
- `ItemPost` 생성 후 `AFTER_COMMIT` 이벤트 발행
- `ItemPostCreatedEventListener`에서 시간표 매칭 사용자 조회 후 알림 전송
- `ItemReportedPayload` 및 `NotificationType.ITEM_REPORTED` 추가

### 2. 시간표 매칭 조건 개선
- 전체 사용자 스캔 대신 전용 쿼리로 대상 사용자 조회
- primary 시간표 기준으로 조회
- 같은 건물, 같은 요일, 같은 시간대 조건을 모두 만족하는 사용자만 매칭
- `DayOfWeek` 변환 로직을 공통화해 CCTV 쪽 매칭 로직에도 재사용

### 3. 알림 이벤트 처리 정리
- `NotificationDispatchEventListener` 처리 방식 조정
- 게시글 알림 발송 흐름에서 dispatch 이벤트가 정상적으로 이어지도록 정리

### 4. 반환 처리 리팩터링
- 물품 반환 시 `Item` 상태 변경과 관련 채팅방 종료를 동일 트랜잭션에서 처리
- 알림 전송은 후속 이벤트로 분리
- `ChatRoomResolutionService` 추가

### 5. 내부 호출 규칙 명시
- `ServiceOnly` 어노테이션 추가
- `ServiceOnlyArchitectureTest` 추가
- 특정 내부 메소드를 허용된 서비스에서만 사용해야 한다는 규칙을 테스트로 검증
- `ServiceOnlyArchitectureTest` 테스트 시 아래와 같이 확인 가능
```
java.lang.AssertionError: Architecture Violation [Priority: MEDIUM] - Rule 'no classes that are not allowed callers should call method Item.changeStatus(ItemStatus)' was violated (2 times):
Method <com.zoopick.server.itemmatch.service.ItemMatchService.matchManual(com.zoopick.server.itemmatch.dto.MatchManualRequest)> calls method <com.zoopick.server.item.entity.Item.changeStatus(com.zoopick.server.item.entity.ItemStatus)> in (ItemMatchService.java:195)
Method <com.zoopick.server.itemmatch.service.ItemMatchService.matchManual(com.zoopick.server.itemmatch.dto.MatchManualRequest)> calls method <com.zoopick.server.item.entity.Item.changeStatus(com.zoopick.server.item.entity.ItemStatus)> in (ItemMatchService.java:196)
```

### 6. DB 변경
- `notification_type` enum에 `ITEM_REPORTED` 추가

## 영향 범위

- 게시글 생성 후 알림 발송
- 알림 저장 및 dispatch
- 물품 반환 처리
- 시간표 매칭 조회 로직
- 내부 아키텍처 검증 테스트

## 체크 포인트

- `ITEM_REPORTED` enum이 반영된 DB 스키마가 적용되어야 합니다.
- 시간표 매칭 알림은 `reportedBuilding`, 요일, 시간 조건에 따라 대상이 좁아집니다.
- `ServiceOnly` 규칙에 걸리는 기존 직접 호출부가 있으면 아키텍처 테스트에서 실패할 수 있습니다.

Resolves: #123 