### PR TITLE
Feat: item_status 필드 추가

### DIFF
--- a/src/main/java/com/zoopick/server/chat/dto/ChatRoomRecord.java
+++ b/src/main/java/com/zoopick/server/chat/dto/ChatRoomRecord.java
@@ -2,6 +2,7 @@ package com.zoopick.server.chat.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.zoopick.server.chat.entity.ChatRoomStatus;
+import com.zoopick.server.item.entity.ItemStatus;
 import lombok.*;
 
 @Getter
@@ -21,4 +22,6 @@ public class ChatRoomRecord {
     private String itemName;
     @JsonProperty("item_id")
     private Long itemId;
+    @JsonProperty("item_status")
+    private ItemStatus itemStatus;
 }

--- a/src/main/java/com/zoopick/server/chat/mapper/ChatRoomMapper.java
+++ b/src/main/java/com/zoopick/server/chat/mapper/ChatRoomMapper.java
@@ -3,6 +3,7 @@ package com.zoopick.server.chat.mapper;
 import com.zoopick.server.chat.dto.ChatRoomRecord;
 import com.zoopick.server.chat.entity.ChatRoom;
 import com.zoopick.server.item.entity.Item;
+import com.zoopick.server.item.entity.ItemStatus;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
@@ -18,6 +19,7 @@ public class ChatRoomMapper {
                 .finderNickname(chatRoom.getFinder().getNickname())
                 .itemName(resolveItemDetail(chatRoom.getItem()))
                 .itemId(resolveItemId(chatRoom.getItem()))
+                .itemStatus(resolveItemStatus(chatRoom.getItem()))
                 .build();
     }
 
@@ -32,5 +34,12 @@ public class ChatRoomMapper {
         if (item == null)
             return null;
         return item.getId();
+    }
+
+    @Nullable
+    private ItemStatus resolveItemStatus(@Nullable Item item) {
+        if (item == null)
+            return null;
+        return item.getStatus();
     }
 }


### PR DESCRIPTION
-ChatRoomRecord.java: item_status 필드 추가 (ItemStatus, nullable)
-ChatRoomMapper.java: resolveItemStatus() 메서드 추가 및 매핑 연결

QR 스캔 채팅방은 item_status: null, 게시글 기반은 "REPORTED" / "IN_LOCKER" 등 실제 상태값이 내려감 

#130
