### PR TITLE
Feat: user_id 프로필에 추가

### DIFF
--- a/src/main/java/com/zoopick/server/profile/dto/ProfileSummaryResponse.java
+++ b/src/main/java/com/zoopick/server/profile/dto/ProfileSummaryResponse.java
@@ -1,6 +1,7 @@
 package com.zoopick.server.profile.dto;
 
 public record ProfileSummaryResponse(
+        long userId,
         String nickname,
         String department,
         long postCount,

--- a/src/main/java/com/zoopick/server/profile/service/ProfileService.java
+++ b/src/main/java/com/zoopick/server/profile/service/ProfileService.java
@@ -31,6 +31,7 @@ public class ProfileService {
         long unreadCount = notificationRepository.countByUserIdAndReadAtIsNull(userId);
 
         return new ProfileSummaryResponse(
+                userId,
                 user.getNickname(),
                 user.getDepartment(),
                 postCount,

--- a/src/test/java/com/zoopick/server/service/ProfileServiceTest.java
+++ b/src/test/java/com/zoopick/server/service/ProfileServiceTest.java
@@ -64,6 +64,7 @@ class ProfileServiceTest {
 
         // then
         assertNotNull(response);
+        assertEquals(USER_ID, response.userId());
         assertEquals("기존닉네임", response.nickname());
         assertEquals("컴퓨터공학과", response.department());
         assertEquals(5L, response.postCount());


### PR DESCRIPTION
 ## 변경 사항

  ### 1. ChatRoomRecord에 item_status 추가
  프론트엔드에서 채팅방 모달 버튼 분기 시 물건의 사물함 보관 여부를 알 수 없는 문제 해결

  - `ChatRoomRecord`에 `item_status` 필드 추가 (nullable)
  - `ChatRoomMapper`에 `resolveItemStatus()` 메서드 추가
  - QR 스캔 채팅방: `null` / 게시글 기반: `REPORTED` | `IN_LOCKER` 등 실제 상태값 반환

  ### 2. ProfileSummaryResponse에 userId 추가
  프론트엔드 요청에 따라 `GET /api/profiles/me` 응답에 `userId` 필드 추가

  ## 영향 파일
  - `ChatRoomRecord.java`
  - `ChatRoomMapper.java`
  - `ProfileSummaryResponse.java`
  - `ProfileService.java`
