### PR TITLE
Fix: 알림 읽기 오류 수정

### DIFF
--- a/src/main/java/com/zoopick/server/notification/dto/ChangeReadStatusRequest.java
+++ b/src/main/java/com/zoopick/server/notification/dto/ChangeReadStatusRequest.java
@@ -1,7 +1,6 @@
 package com.zoopick.server.notification.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,7 +11,6 @@ import java.util.List;
 @Setter
 @AllArgsConstructor
 public class ChangeReadStatusRequest {
-    @NotBlank
     @JsonProperty("notification_ids")
     private List<Long> notificationIds;
 }

--- a/src/main/java/com/zoopick/server/notification/event/NotificationDispatchEventListener.java
+++ b/src/main/java/com/zoopick/server/notification/event/NotificationDispatchEventListener.java
@@ -31,7 +31,9 @@ public class NotificationDispatchEventListener {
         try {
             if (!messages.isEmpty()) {
                 BatchResponse response = FirebaseMessaging.getInstance().sendEach(messages);
-                log.warn("{} notifications failed to send", response.getFailureCount());
+                int failedCount = response.getFailureCount();
+                if (failedCount > 0)
+                    log.warn("{} notifications failed to send", failedCount);
             }
         } catch (FirebaseMessagingException exception) {
             log.error(exception.getMessage(), exception);


### PR DESCRIPTION
- ChangeReadStatusRequest#notificationIds 의 NotBlank 제거
- FCM 알림 실패 시에만 로그 출력