### PR TITLE
Fix: itemPost에 reported_at, nickname 추가

### DIFF
--- a/src/main/java/com/zoopick/server/item/CreateItemCommand.java
+++ b/src/main/java/com/zoopick/server/item/CreateItemCommand.java
@@ -18,7 +18,7 @@ public record CreateItemCommand(
         String imageUrl,
         Building building,
         String detailAddress,
-        OffsetDateTime reportedAd
+        OffsetDateTime reportedAt
 ) {
 
 }

--- a/src/main/java/com/zoopick/server/item/mapper/CreateItemCommandMapper.java
+++ b/src/main/java/com/zoopick/server/item/mapper/CreateItemCommandMapper.java
@@ -19,7 +19,7 @@ public class CreateItemCommandMapper {
                 .imageUrl(request.getImageUrl())
                 .building(building)
                 .detailAddress(request.getDetailAddress())
-                .reportedAd(request.getReportedAt())
+                .reportedAt(request.getReportedAt())
                 .build();
     }
 

--- a/src/main/java/com/zoopick/server/item/service/ItemService.java
+++ b/src/main/java/com/zoopick/server/item/service/ItemService.java
@@ -48,8 +48,8 @@ public class ItemService {
                 .reportedBuilding(command.building())
                 .locationName(command.detailAddress())
                 .imageUrl(command.imageUrl())
-                .reportedAt(command.reportedAd() != null
-                        ? command.reportedAd().atZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime()
+                .reportedAt(command.reportedAt() != null
+                        ? command.reportedAt().atZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime()
                         : LocalDateTime.now())
                 .build();
 

--- a/src/main/java/com/zoopick/server/itempost/dto/ItemPostRecord.java
+++ b/src/main/java/com/zoopick/server/itempost/dto/ItemPostRecord.java
@@ -37,4 +37,7 @@ public class ItemPostRecord {
     private String detailAddress;
     @JsonProperty("created_at")
     private LocalDateTime createdAt;
+    @JsonProperty("reported_at")
+    private LocalDateTime reportedAt;
+    private String nickname;
 }

--- a/src/main/java/com/zoopick/server/itempost/mapper/ItemPostMapper.java
+++ b/src/main/java/com/zoopick/server/itempost/mapper/ItemPostMapper.java
@@ -26,6 +26,8 @@ public class ItemPostMapper {
                 .buildingId(itemPost.getItem().getReportedBuilding().getId())
                 .detailAddress(itemPost.getItem().getLocationName())
                 .createdAt(itemPost.getCreatedAt())
+                .reportedAt(itemPost.getItem().getReportedAt())
+                .nickname(itemPost.getUser().getNickname())
                 .build();
     }
 }


### PR DESCRIPTION
  1. CreateItemPostRequest → @JsonProperty("reported_at")으로 OffsetDateTime reportedAt 바인딩 
  2. CreateItemCommandMapper → request.getReportedAt()을 CreateItemCommand.reportedAd에 매핑 
  3. ItemService.createItem() → command.reportedAd()를 Asia/Seoul 기준 LocalDateTime으로 변환 후 item.reportedAt에 저장 


 ItemPostRecord에 reported_at, nickname 필드를 추가하고, ItemPostMapper에서 item.getReportedAt()과 user.getNickname()을 매핑하도록 수정

#135 